### PR TITLE
Fix weighted segfault

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -827,7 +827,7 @@ FSTProcessor::load(FILE *input)
       name += static_cast<wchar_t>(Compression::multibyte_read(input));
       len2--;
     }
-    transducers[name].read(input, alphabet, true);
+    transducers[name].read(input, alphabet);
     len--;
   }
 }

--- a/lttoolbox/lt_print.cc
+++ b/lttoolbox/lt_print.cc
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
       name += static_cast<wchar_t>(Compression::multibyte_read(input));
       len2--;
     }
-    transducers[name].read(input, 0, true);
+    transducers[name].read(input);
 
     len--;
   }

--- a/lttoolbox/lt_trim.cc
+++ b/lttoolbox/lt_trim.cc
@@ -66,7 +66,7 @@ read_fst(FILE *bin_file)
       name += static_cast<wchar_t>(Compression::multibyte_read(bin_file));
       len2--;
     }
-    transducers[name].read(bin_file, 0, true);
+    transducers[name].read(bin_file);
 
     len--;
   }

--- a/lttoolbox/pattern_list.cc
+++ b/lttoolbox/pattern_list.cc
@@ -370,7 +370,7 @@ PatternList::write(FILE *output)
 
   Compression::multibyte_write(1, output);
   Compression::wstring_write(tagger_name, output);
-  transducer.write(output, alphabet.size(), false);
+  transducer.write(output, alphabet.size());
 
   Compression::multibyte_write(final_type.size(), output);
 
@@ -392,7 +392,7 @@ PatternList::read(FILE *input)
   if(Compression::multibyte_read(input) == 1)
   {
     wstring mystr = Compression::wstring_read(input);
-    transducer.read(input, alphabet.size(), false);
+    transducer.read(input, alphabet.size());
 
     int finalsize = Compression::multibyte_read(input);
     for(; finalsize != 0; finalsize--)

--- a/lttoolbox/tmx_compiler.cc
+++ b/lttoolbox/tmx_compiler.cc
@@ -458,7 +458,7 @@ TMXCompiler::write(FILE *output)
   // transducers
   Compression::multibyte_write(1, output); // keeping file format
   Compression::wstring_write(L"", output); // keeping file format
-  transducer.write(output, 0, false);
+  transducer.write(output);
 
   wcout << origin_language << L"->" << meta_language << L" ";
   wcout << transducer.size() << L" " << transducer.numberOfTransitions();

--- a/lttoolbox/trans_exe.cc
+++ b/lttoolbox/trans_exe.cc
@@ -64,18 +64,25 @@ TransExe::destroy()
 #include <iostream>
 
 void
-TransExe::read(FILE *input, Alphabet const &alphabet, bool read_weights)
+TransExe::read(FILE *input, Alphabet const &alphabet)
 {
   TransExe &new_t = *this;
   new_t.destroy();
-  new_t.initial_id = Compression::multibyte_read(input);
+
+  bool read_weights = false;
+  double modified_initial = Compression::long_multibyte_read(input);
+  int initial_value = static_cast<int>(modified_initial);
+  if(modified_initial != static_cast<double>(initial_value))
+  {
+    read_weights = true;
+  }
+  new_t.initial_id = initial_value;
   int finals_size = Compression::multibyte_read(input);
 
   int base = 0;
   double base_weight = default_weight;
 
   map<int, double> myfinals;
-
 
   while(finals_size > 0)
   {

--- a/lttoolbox/trans_exe.h
+++ b/lttoolbox/trans_exe.h
@@ -96,7 +96,7 @@ public:
    * @param input the stream
    * @param alphabet the alphabet object to decode the symbols
    */
-  void read(FILE *input, Alphabet const &alphabet, bool read_weights);
+  void read(FILE *input, Alphabet const &alphabet);
 
   /**
    * Reduces all the final states to one

--- a/lttoolbox/transducer.cc
+++ b/lttoolbox/transducer.cc
@@ -503,7 +503,8 @@ Transducer::isEmpty(int const state) const
 void
 Transducer::write(FILE *output, int const decalage, bool write_weights)
 {
-  Compression::multibyte_write(initial, output);
+  double modify_initial = initial + double(write_weights)/10;
+  Compression::long_multibyte_write(modify_initial, output);
   Compression::multibyte_write(finals.size(), output);
 
   int base = 0;
@@ -552,11 +553,18 @@ Transducer::write(FILE *output, int const decalage, bool write_weights)
 }
 
 void
-Transducer::read(FILE *input, int const decalage, bool read_weights)
+Transducer::read(FILE *input, int const decalage)
 {
   Transducer new_t;
 
-  new_t.initial = Compression::multibyte_read(input);
+  bool read_weights = false;
+  double modified_initial = Compression::long_multibyte_read(input);
+  int initial_value = static_cast<int>(modified_initial);
+  if(modified_initial != static_cast<double>(initial_value))
+  {
+    read_weights = true;
+  }
+  new_t.initial = initial_value;
   int finals_size = Compression::multibyte_read(input);
 
   int base = 0;

--- a/lttoolbox/transducer.h
+++ b/lttoolbox/transducer.h
@@ -298,7 +298,7 @@ public:
    * @param input the stream to read from
    * @param decalage offset to sum to the tags
    */
-  void read(FILE *input, int const decalage = 0, bool read_weights = false);
+  void read(FILE *input, int const decalage = 0);
 
   void serialise(std::ostream &serialised) const;
   void deserialise(std::istream &serialised);


### PR DESCRIPTION
Modify binary read and write functions to prevent
segmentation fault.

Fixes https://github.com/apertium/lttoolbox/issues/27