### PR TITLE
Remove duplicate "w" in dix.xsd

### DIFF
--- a/lttoolbox/xsd/dix.xsd
+++ b/lttoolbox/xsd/dix.xsd
@@ -120,7 +120,6 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="lm"/>
-      <xs:attribute name="w"/>
       <xs:attribute name="a"/>
       <xs:attribute name="c"/>
       <xs:attribute name="i"/>


### PR DESCRIPTION
Attribute "w" for dix entries is declared twice, resulting in a warning when compiling dictionaries. This fixes the issue.