### PR TITLE
Put spaces in blankqueue too, popping if we write a word with spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
-**.deps/
+**/*.deps/
+/.ccls-cache/
 /*.pc
 /aclocal.m4
 /autom4te.cache
@@ -57,3 +58,16 @@
 *.out
 *.app
 
+/compile_commands.json
+/lttoolbox/lt-comp
+/lttoolbox/lt-proc
+/lttoolbox/lt-trim
+/lttoolbox/Makefile
+/lttoolbox/Makefile.in
+/lttoolbox/lt-tmxcomp
+/lttoolbox/lt-print
+/lttoolbox/stamp-h1
+/lttoolbox/lttoolbox_config.h.in
+/lttoolbox/lttoolbox_config.h
+/lttoolbox/lt-tmxproc
+/lttoolbox/lt-expand

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005 Universitat d'Alacant / Universidad de Alicante
+ * Copyright (C) 2005-2019 Universitat d'Alacant / Universidad de Alicante
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -267,14 +267,14 @@ private:
   bool isEscaped(wchar_t const c) const;
 
   /**
-   * Read text from stream (analysis version, also used in postgeneration)
+   * Read text from stream (analysis version)
    * @param input the stream to read
    * @return the next symbol in the stream
    */
   int readAnalysis(FILE *input);
 
   /**
-   * Read text from stream (generation version, also used in generation)
+   * Read text from stream (decomposition version)
    * @param input the stream to read
    * @return the next symbol in the stream
    */
@@ -331,6 +331,14 @@ private:
    */
   void writeEscaped(wstring const &str, FILE *output);
 
+  /**
+   * Write a string to an output stream.
+   * If we print a space, we may pop a space from blankqueue.
+   *
+   * @param str the string to write, escaping characters
+   * @param output the stream to write in
+   */
+  void writeEscapedPopBlanks(wstring const &str, FILE *output);
 
   /**
    * Write a string to an output stream, escaping all escapable characters
@@ -356,6 +364,16 @@ private:
    * @param output stream where the word is written
    */
   void printWord(wstring const &sf, wstring const &lf, FILE *output);
+
+  /**
+   * Prints a word.
+   * If we print a space, we may pop a space from blankqueue.
+   *
+   * @param sf surface form of the word
+   * @param lf lexical form of the word
+   * @param output stream where the word is written
+   */
+  void printWordPopBlank(wstring const &sf, wstring const &lf, FILE *output);
 
   /**
    * Prints a word (Bilingual version)
@@ -386,7 +404,15 @@ private:
   int readTMAnalysis(FILE *input);
 
   unsigned int lastBlank(wstring const &str);
+
+  /**
+   * Print one blankqueue item if there is one, or a given "space" value.
+   *
+   * @param val the space character to use if no blank queue
+   * @param output stream where the word is written
+   */
   void printSpace(wchar_t const val, FILE *output);
+
   void skipUntil(FILE *input, FILE *output, wint_t const character);
   static wstring removeTags(wstring const &str);
   wstring compoundAnalysis(wstring str, bool uppercase, bool firstupper);

--- a/tests/data/gardenpath-mwe.dix
+++ b/tests/data/gardenpath-mwe.dix
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+  <sdefs>
+    <sdef n="vblex"/>
+    <sdef n="inf"/>
+    <sdef n="pr"/>
+    <sdef n="prn"/>
+  </sdefs>
+  <pardefs>
+  </pardefs>
+
+  <section id="main" type="standard">
+    <e><p><l>legge</l> <r>legge<s n="vblex"/><s n="inf"/></r></p></e>
+    <e><p><l>legge<b/>opp<b/>til</l> <r>legge<g><b/>opp<b/>til<s n="vblex"/><s n="inf"/></g></r></p></e>
+    <e><p><l>opp</l> <r>opp<s n="pr"/></r></p></e>
+
+    <e><p><l>legge<b/>seg<b/>opp<b/>til</l> <r>legge<g><b/>seg<b/>opp<b/>til<s n="vblex"/><s n="inf"/></g></r></p></e>
+    <e><p><l>seg</l> <r>seg<s n="prn"/></r></p></e>
+  </section>
+
+</dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -92,5 +92,22 @@ class Intergeneration(unittest.TestCase, ProcTest):
     inputs = ["la dona ~dóna tot"]
     expectedOutputs = ["la dona dona tot"]
 
+class GardenPathMwe(unittest.TestCase, ProcTest):
+    procdix = "data/gardenpath-mwe.dix"
+    inputs          = ["x[ <br/> ]opp.",
+                        "legge opp[<br/>]x.",
+                       "y[A]x",
+                        "[A]y x",
+                        "legge opp[<br/>]",
+                        "legge[][\n]L[<\/p>\n]",
+                       ]
+    expectedOutputs = ["^x/*x$[ <br/> ]^opp/opp<pr>$.",
+                        "^legge/legge<vblex><inf>$ ^opp/opp<pr>$[<br/>]^x/*x$.",
+                       "^y/*y$[A]^x/*x$",
+                        "[A]^y/*y$ ^x/*x$",
+                        "^legge/legge<vblex><inf>$ ^opp/opp<pr>$[<br/>]",
+                        "^legge/legge<vblex><inf>$[][\n]^L/*L$[<\/p>\n]",
+                       ]
+
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *

--- a/tests/proctest.py
+++ b/tests/proctest.py
@@ -66,6 +66,8 @@ class ProcTest():
                               stdout=PIPE,
                               stderr=PIPE)
 
+            self.assertEqual(len(self.inputs),
+                             len(self.expectedOutputs))
             for inp, exp in zip(self.inputs, self.expectedOutputs):
                 self.assertEqual(self.communicateFlush(inp+"[][\n]"),
                                  exp+"[][\n]")


### PR DESCRIPTION
and only print *one* item from blankqueue in printSpace.

This fixes #47. With the input `legge opp<br/>blah`, we'll now have
the regular space in blankqueue and use that before getting to the
<br/>.

Tested on 100.000 lines of html with nno-nob, only good changes found,
and seems to work fine with flushing.