### PR TITLE
add HFST compatibility option to lt-print

### DIFF
--- a/lttoolbox/lt_print.cc
+++ b/lttoolbox/lt_print.cc
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
   for(map<wstring, Transducer>::iterator it = transducers.begin(); it != transducers.end(); it++)
   {
     it->second.joinFinals();
-    it->second.show(alphabet, output, hfst);
+    it->second.show(alphabet, output, 0, hfst);
     if(it != penum)
     {
       fwprintf(output, L"--\n", it->first.c_str());

--- a/lttoolbox/lt_print.cc
+++ b/lttoolbox/lt_print.cc
@@ -34,7 +34,7 @@ void endProgram(char *name)
   if(name != NULL)
   {
     cout << basename(name) << " v" << PACKAGE_VERSION <<": dump a transducer to text in ATT format" << endl;
-    cout << "USAGE: " << basename(name) << " [-Hh] bin_file " << endl;
+    cout << "USAGE: " << basename(name) << " [-Hh] bin_file [output_file] " << endl;
     cout << "    -H, --hfst:     use HFST-compatible character escapes" << endl;
     cout << "    -h, --help:     print this message and exit" << endl;
   }

--- a/lttoolbox/lt_print.cc
+++ b/lttoolbox/lt_print.cc
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <libgen.h>
 #include <string>
+#include <getopt.h>
 
 using namespace std;
 
@@ -33,7 +34,9 @@ void endProgram(char *name)
   if(name != NULL)
   {
     cout << basename(name) << " v" << PACKAGE_VERSION <<": dump a transducer to text in ATT format" << endl;
-    cout << "USAGE: " << basename(name) << " bin_file " << endl;
+    cout << "USAGE: " << basename(name) << " [-Hh] bin_file " << endl;
+    cout << "    -H, --hfst:     use HFST-compatible character escapes" << endl;
+    cout << "    -h, --help:     print this message and exit" << endl;
   }
   exit(EXIT_FAILURE);
 }
@@ -41,19 +44,78 @@ void endProgram(char *name)
 
 int main(int argc, char *argv[])
 {
-  if(argc != 2)
-  {
-    endProgram(argv[0]);
-  }
+  bool hfst = false;
+  FILE* input = NULL;
+  FILE* output = stdout;
 
   LtLocale::tryToSetLocale();
 
+#if HAVE_GETOPT_LONG
+  int option_index=0;
+#endif
 
-  FILE *input = fopen(argv[1], "rb");
+  while (true) {
+#if HAVE_GETOPT_LONG
+    static struct option long_options[] =
+    {
+      {"hfst",      no_argument, 0, 'H'},
+      {"help",      no_argument, 0, 'h'},
+      {0, 0, 0, 0}
+    };
+
+    int cnt=getopt_long(argc, argv, "Hh", long_options, &option_index);
+#else
+    int cnt=getopt(argc, argv, "Hh");
+#endif
+    if (cnt==-1)
+      break;
+
+    switch (cnt)
+    {
+      case 'H':
+        hfst = true;
+        break;
+
+      case 'h':
+      default:
+        endProgram(argv[0]);
+        break;
+    }
+  }
+
+  string infile;
+  string outfile;
+  switch(argc - optind)
+  {
+    case 1:
+      infile = argv[argc-1];
+      break;
+
+    case 2:
+      infile = argv[argc-2];
+      outfile = argv[argc-1];
+      break;
+
+    default:
+      endProgram(argv[0]);
+      break;
+  }
+
+  input = fopen(infile.c_str(), "rb");
   if(!input)
   {
-    wcerr << "Error: Cannot open file '" << argv[1] << "'." << endl;
+    cerr << "Error: Cannot open file '" << infile << "' for reading." << endl;
     exit(EXIT_FAILURE);
+  }
+
+  if(outfile != "")
+  {
+    output = fopen(outfile.c_str(), "w");
+    if(!output)
+    {
+      cerr << "Error: Cannot open file '" << outfile << "' for writing." << endl;
+      exit(EXIT_FAILURE);
+    }
   }
 
   Alphabet alphabet;
@@ -106,13 +168,12 @@ int main(int argc, char *argv[])
 
   /////////////////////
 
-  FILE *output = stdout;
   map<wstring, Transducer>::iterator penum = transducers.end();
   penum--;
   for(map<wstring, Transducer>::iterator it = transducers.begin(); it != transducers.end(); it++)
   {
     it->second.joinFinals();
-    it->second.show(alphabet, output);
+    it->second.show(alphabet, output, hfst);
     if(it != penum)
     {
       fwprintf(output, L"--\n", it->first.c_str());
@@ -120,6 +181,10 @@ int main(int argc, char *argv[])
   }
 
   fclose(input);
+  if(output != stdout)
+  {
+    fclose(output);
+  }
 
   return 0;
 }

--- a/lttoolbox/transducer.cc
+++ b/lttoolbox/transducer.cc
@@ -724,7 +724,7 @@ Transducer::escapeSymbol(wstring& symbol, bool hfst) const
 }
 
 void
-Transducer::show(Alphabet const &alphabet, FILE *output, bool hfst, int const epsilon_tag) const
+Transducer::show(Alphabet const &alphabet, FILE *output, int const epsilon_tag, bool hfst) const
 {
   for(auto& it : transitions)
   {

--- a/lttoolbox/transducer.cc
+++ b/lttoolbox/transducer.cc
@@ -700,7 +700,31 @@ Transducer::reverse(int const epsilon_tag)
 }
 
 void
-Transducer::show(Alphabet const &alphabet, FILE *output, int const epsilon_tag) const
+Transducer::escapeSymbol(wstring& symbol, bool hfst) const
+{
+  if(symbol == L"") // If it's an epsilon
+  {
+    if(hfst)
+    {
+      symbol = L"@0@";
+    }
+    else
+    {
+      symbol = L"ε";
+    }
+  }
+  else if(hfst && symbol == L" ")
+  {
+    symbol = L"@SPACE@";
+  }
+  else if(hfst && symbol == L"\t")
+  {
+    symbol = L"@TAB@";
+  }
+}
+
+void
+Transducer::show(Alphabet const &alphabet, FILE *output, bool hfst, int const epsilon_tag) const
 {
   for(auto& it : transitions)
   {
@@ -711,24 +735,12 @@ Transducer::show(Alphabet const &alphabet, FILE *output, int const epsilon_tag) 
       fwprintf(output, L"%d\t", it2.second.first);
       wstring l = L"";
       alphabet.getSymbol(l, t.first);
-      if(l == L"")  // If we find an epsilon
-      {
-        fwprintf(output, L"ε\t", l.c_str());
-      }
-      else
-      {
-        fwprintf(output, L"%S\t", l.c_str());
-      }
+      escapeSymbol(l, hfst);
+      fwprintf(output, L"%S\t", l.c_str());
       wstring r = L"";
       alphabet.getSymbol(r, t.second);
-      if(r == L"")  // If we find an epsilon
-      {
-        fwprintf(output, L"ε\t", r.c_str());
-      }
-      else
-      {
-        fwprintf(output, L"%S\t", r.c_str());
-      }
+      escapeSymbol(r, hfst);
+      fwprintf(output, L"%S\t", r.c_str());
       fwprintf(output, L"%f\t", it2.second.second);
       fwprintf(output, L"\n");
     }

--- a/lttoolbox/transducer.h
+++ b/lttoolbox/transducer.h
@@ -81,6 +81,13 @@ private:
    * Empty transducer
    */
   void destroy();
+
+  /**
+   * Helper function for show()
+   * @param symbol the string to be escaped
+   * @param hfst if true, use HFST-compatible escape sequences
+   */
+  void escapeSymbol(wstring& symbol, bool hfst) const;
 public:
 
   /**
@@ -213,9 +220,10 @@ public:
 
   /**
    * Print all the transductions of a transducer in ATT format
+   * @param hfst if true, use HFST-compatible escape characters
    * @param epsilon_tag the tag to take as epsilon
    */
-  void show(Alphabet const &a, FILE *output = stdout, int const epsilon_tag = 0) const;
+  void show(Alphabet const &a, FILE *output = stdout, bool hfst = false, int const epsilon_tag = 0) const;
 
   /**
    * Determinize the transducer

--- a/lttoolbox/transducer.h
+++ b/lttoolbox/transducer.h
@@ -223,7 +223,7 @@ public:
    * @param hfst if true, use HFST-compatible escape characters
    * @param epsilon_tag the tag to take as epsilon
    */
-  void show(Alphabet const &a, FILE *output = stdout, bool hfst = false, int const epsilon_tag = 0) const;
+  void show(Alphabet const &a, FILE *output = stdout, int const epsilon_tag = 0, bool hfst = false) const;
 
   /**
    * Determinize the transducer


### PR DESCRIPTION
This PR adds a `-H`/`--hfst` option to `lt-print` to print transducers with character escapes that can be read by `hfst-txt2fst`. It also adds this option to `transducer.show()`.

(In case anyone wonders, the argument order on `show()` is because if the `hfst` parameter is last and you try to pass in a `bool`, it gets casted to an `int` and interpreted as `epsilon_tag`.)