### PR TITLE
typo in HFST symbol escapes

### DIFF
--- a/lttoolbox/transducer.cc
+++ b/lttoolbox/transducer.cc
@@ -715,11 +715,11 @@ Transducer::escapeSymbol(wstring& symbol, bool hfst) const
   }
   else if(hfst && symbol == L" ")
   {
-    symbol = L"@SPACE@";
+    symbol = L"@_SPACE_@";
   }
   else if(hfst && symbol == L"\t")
   {
-    symbol = L"@TAB@";
+    symbol = L"@_TAB_@";
   }
 }
 


### PR DESCRIPTION
When I added HFST mode to lt-print I mistyped the character escapes because the underscores were interpreted as markdown in the documentation I was reading and I didn't test thoroughly enough to catch it.