### PR TITLE
Ignoring secondary tags during generation

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -542,6 +542,16 @@ FSTProcessor::readGeneration(FILE *input, FILE *output)
         {
           streamError();
         }
+        
+        if(val == L'\\')
+        {
+          val = fgetwc_unlocked(input);
+          continue;
+        }
+        else if(val == L'#')
+        {
+          return static_cast<int>(L'#');
+        }
       }
         
       outOfWord = true;

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -564,13 +564,13 @@ FSTProcessor::readGeneration(FILE *input, FILE *output)
           {
             isSecondaryTag = true;
           }
-          else if(val == L'#')
-          {
-            return static_cast<int>(L'#');
-          }
           else if(val == L'$')
           {
               break;
+          }
+          else
+          {
+            return static_cast<int>(val);
           }
         }
       }

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -538,7 +538,10 @@ FSTProcessor::readGeneration(FILE *input, FILE *output)
     {
       while((val = fgetwc_unlocked(input)) != L'$')
       {
-        //do nothing
+        if(feof(input))
+        {
+          streamError();
+        }
       }
         
       outOfWord = true;

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -516,17 +516,39 @@ FSTProcessor::readGeneration(FILE *input, FILE *output)
   {
     wstring cad = L"";
     cad += static_cast<wchar_t>(val);
+      
+    bool isSecondaryTag = false;
+      
     while((val = fgetwc_unlocked(input)) != L'>')
     {
       if(feof(input))
       {
         streamError();
       }
+      if(val == L':')
+      {
+        isSecondaryTag = true;
+        break;
+      }
       cad += static_cast<wchar_t>(val);
     }
     cad += static_cast<wchar_t>(val);
-
-    return alphabet(cad);
+    
+    if(isSecondaryTag)
+    {
+      while((val = fgetwc_unlocked(input)) != L'$')
+      {
+        //do nothing
+      }
+        
+      outOfWord = true;
+      return static_cast<int>(L'$');
+    }
+    else
+    {
+      return alphabet(cad);
+    }
+    
   }
   else if(val == L'[')
   {

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -536,8 +536,10 @@ FSTProcessor::readGeneration(FILE *input, FILE *output)
     
     if(isSecondaryTag)
     {
-      while((val = fgetwc_unlocked(input)) != L'$')
+      while(true)
       {
+        val = fgetwc_unlocked(input);
+          
         if(feof(input))
         {
           streamError();
@@ -548,9 +550,28 @@ FSTProcessor::readGeneration(FILE *input, FILE *output)
           val = fgetwc_unlocked(input);
           continue;
         }
-        else if(val == L'#')
+        
+        if(isSecondaryTag)
         {
-          return static_cast<int>(L'#');
+          if(val == L'>')
+          {
+            isSecondaryTag = false;
+          }
+        }
+        else
+        {
+          if(val == L'<')
+          {
+            isSecondaryTag = true;
+          }
+          else if(val == L'#')
+          {
+            return static_cast<int>(L'#');
+          }
+          else if(val == L'$')
+          {
+              break;
+          }
         }
       }
         


### PR DESCRIPTION
- Removes all trailing secondary tags from the input before giving it to FST matching.
- For input without secondary tags it works as earlier with no regression.
- All escaped characters are ignored inside secondary tags, as well as unescaped special characters ($,#,etc.) This applies for the tag prefix as well

This is needed for generation.
Input:
```
^The<det><def><pl><sf:Los>$ ^dog<n><pl><sf:perros>$ ^of<pr><sf:del>$ ^the<det><def><sg><sf:del>$ ^boy<n><sg><sf:chico>$ ^run<vblex><pres><sf:corren>$ ^fast<adj><sint><sf:rápido>$^.<sent><sf:.>$^.<sent><sf:.>$[][
]
```
Earlier Output:
```
 #The #dog #of #the #boy #run #fast#.#.[][
]
```
New Output:
```
The dogs of the boy run fast..[][
]
```