### PR TITLE
Add the possibility of defining morpheme boundaries 

### DIFF
--- a/lttoolbox/compiler.cc
+++ b/lttoolbox/compiler.cc
@@ -44,6 +44,7 @@ wstring const Compiler::COMPILER_PAIR_ELEM          = L"p";
 wstring const Compiler::COMPILER_LEFT_ELEM          = L"l";
 wstring const Compiler::COMPILER_RIGHT_ELEM         = L"r";
 wstring const Compiler::COMPILER_S_ELEM             = L"s";
+wstring const Compiler::COMPILER_M_ELEM             = L"m";
 wstring const Compiler::COMPILER_REGEXP_ELEM        = L"re";
 wstring const Compiler::COMPILER_SECTION_ELEM       = L"section";
 wstring const Compiler::COMPILER_ID_ATTR            = L"id";
@@ -318,6 +319,14 @@ Compiler::readString(list<int> &result, wstring const &name)
     for(unsigned int i = 0, limit = value.size(); i < limit; i++)
     {
       result.push_back(static_cast<int>(value[i]));
+    }
+  }
+  else if(name == COMPILER_M_ELEM)
+  {
+    requireEmptyError(name);
+    if(keep_boundaries) 
+    {
+      result.push_back(static_cast<int>(L'>'));
     }
   }
   else if(name == COMPILER_BLANK_ELEM)
@@ -959,6 +968,11 @@ Compiler::setVariantRightValue(string const &v)
   variant_right = XMLParseUtil::stows(v);
 }
 
+void
+Compiler::setKeepBoundaries(bool keep)
+{
+  keep_boundaries = keep;
+}
 void
 Compiler::setVerbose(bool verbosity)
 {

--- a/lttoolbox/compiler.cc
+++ b/lttoolbox/compiler.cc
@@ -973,6 +973,7 @@ Compiler::setKeepBoundaries(bool keep)
 {
   keep_boundaries = keep;
 }
+
 void
 Compiler::setVerbose(bool verbosity)
 {

--- a/lttoolbox/compiler.h
+++ b/lttoolbox/compiler.h
@@ -108,6 +108,12 @@ private:
   double default_weight;
 
   /**
+   * Maintain morpheme boundaries 
+   */
+  bool keep_boundaries;
+
+
+  /**
    * Identifier of all the symbols during the compilation
    */
   Alphabet alphabet;
@@ -303,6 +309,7 @@ public:
   LTTOOLBOX_IMPORTS static wstring const COMPILER_LEFT_ELEM;
   LTTOOLBOX_IMPORTS static wstring const COMPILER_RIGHT_ELEM;
   LTTOOLBOX_IMPORTS static wstring const COMPILER_S_ELEM;
+  LTTOOLBOX_IMPORTS static wstring const COMPILER_M_ELEM;
   LTTOOLBOX_IMPORTS static wstring const COMPILER_REGEXP_ELEM;
   LTTOOLBOX_IMPORTS static wstring const COMPILER_SECTION_ELEM;
   LTTOOLBOX_IMPORTS static wstring const COMPILER_ID_ATTR;
@@ -348,6 +355,11 @@ public:
    * @param fd the stream where write the result
    */
   void write(FILE *fd);
+
+  /**
+   * Set keep morpheme boundaries
+   */
+  void setKeepBoundaries(bool keep_boundaries = false);
 
   /**
    * Set verbose output

--- a/lttoolbox/dix.dtd
+++ b/lttoolbox/dix.dtd
@@ -108,7 +108,7 @@
 <!ELEMENT p (l, r)>
 	<!-- pair of strings -->
 
-<!ELEMENT l (#PCDATA | a | b | g | j | s)*>
+<!ELEMENT l (#PCDATA | a | b | g | j | s | m)*>
 	<!-- left part of p -->
 <!ATTLIST l
     c CDATA #IMPLIED
@@ -126,6 +126,9 @@
 
 <!ELEMENT b EMPTY>
 	<!-- blank chars block mark -->
+
+<!ELEMENT m EMPTY>
+	<!-- mark morpheme boundary (left side only) -->
 
 <!ELEMENT ig (#PCDATA | a | b | j | s)*>
 	<!-- 'group identity' - equivalent to <p> where <r> contains <g>, whose contents are the same as those of <l> -->

--- a/lttoolbox/dix.rnc
+++ b/lttoolbox/dix.rnc
@@ -101,7 +101,7 @@ attlist.re &= empty
 p = element p { attlist.p, l, r }
 attlist.p &= empty
 # pair of strings
-l = element l { attlist.l, (text | a | b | g | j | s)* }
+l = element l { attlist.l, (text | a | b | g | j | s | m)* }
 attlist.l &= empty
 # left part of p
 r = element r { attlist.r, (text | a | b | g | j | s)* }
@@ -113,6 +113,9 @@ attlist.a &= empty
 b = element b { attlist.b, empty }
 attlist.b &= empty
 # blank chars block mark
+m = element m { attlist.m, empty }
+attlist.m &= empty
+# morpheme boundary mark
 g = element g { attlist.g, (text | a | b | j | s)* }
 # mark special groups in lemmas
 attlist.g &= attribute i { text }?

--- a/lttoolbox/dix.rng
+++ b/lttoolbox/dix.rng
@@ -265,6 +265,7 @@
           <ref name="g"/>
           <ref name="j"/>
           <ref name="s"/>
+          <ref name="m"/>
         </choice>
       </zeroOrMore>
     </element>
@@ -302,7 +303,17 @@
     <empty/>
   </define>
   <!-- post-generator wake-up mark -->
-  <define name="b">
+  <define name="m">
+    <element name="m">
+      <ref name="attlist.m"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="attlist.m" combine="interleave">
+    <empty/>
+  </define>
+  <!-- morpheme boundary mark --> 
+   <define name="b">
     <element name="b">
       <ref name="attlist.b"/>
       <empty/>

--- a/lttoolbox/expander.cc
+++ b/lttoolbox/expander.cc
@@ -120,6 +120,14 @@ Expander::readString(wstring &result, wstring const &name)
     requireEmptyError(name);
     result += L' ';
   }
+  else if(name == Compiler::COMPILER_M_ELEM)
+  {
+    requireEmptyError(name);
+    if(keep_boundaries)
+    {
+      result += L'>';
+    }
+  }
   else if(name == Compiler::COMPILER_JOIN_ELEM)
   {
     requireEmptyError(name);
@@ -659,3 +667,10 @@ Expander::setVariantRightValue(string const &v)
 {
   variant_right = XMLParseUtil::stows(v);
 }
+
+void
+Expander::setKeepBoundaries(bool keep)
+{
+  keep_boundaries = keep;
+}
+

--- a/lttoolbox/expander.h
+++ b/lttoolbox/expander.h
@@ -72,6 +72,11 @@ private:
   wstring direction;
 
   /**
+   * Do we print boundaries or not?
+   */
+  bool keep_boundaries;
+
+  /**
    * Paradigms
    */
   map<wstring, EntList, Ltstr> paradigm;
@@ -236,6 +241,13 @@ public:
    * @param v the value
    */
    void setVariantRightValue(string const &v);
-};
+
+  /**
+   * Set if we are going to keep morpheme boundaries
+   * @param keep true, false
+   */
+   void setKeepBoundaries(bool keep_boundaries = false);
+
+}; 
 
 #endif

--- a/lttoolbox/lt-comp.1
+++ b/lttoolbox/lt-comp.1
@@ -6,7 +6,7 @@
 .Nd augmented letter transducer compiler for Apertium
 .Sh SYNOPSIS
 .Nm lt-comp
-.Op Fl a | v | l | r | h
+.Op Fl a | v | l | r | m | h
 .Cm lr | rl
 .Ar dictionary_file
 .Ar output_file
@@ -55,6 +55,8 @@ attribute for use in compilation of bidixes.
 here refers to the side of the dictionary, so this option is only valid in
 .Cm lr
 mode.
+.It Fl m , Fl Fl keep-boundaries
+Keep any morpheme boundaries defined by the '<m/>' symbol
 .It Fl h , Fl Fl help
 Prints a short help message.
 .It Cm lr

--- a/lttoolbox/lt-expand.1
+++ b/lttoolbox/lt-expand.1
@@ -6,7 +6,7 @@
 .Nd dictionary expander for Apertium
 .Sh SYNOPSIS
 .Nm lt-expand
-.Op Fl a | v | l | r | h
+.Op Fl a | v | l | r | m | h
 .Ar dictionary_file
 .Op Ar output_file
 .Sh DESCRIPTION
@@ -36,6 +36,8 @@ attribute to use in expansion of bidixes
 Sets the value of the
 .Sy vr
 attribute to use in expansion of bidixes
+.It Fl m , Fl Fl keep-boundaries
+Keep any morpheme boundaries defined by the <m/> symbol
 .It Fl h , Fl Fl help
 Prints a short help message
 .El

--- a/lttoolbox/lt_comp.cc
+++ b/lttoolbox/lt_comp.cc
@@ -42,7 +42,8 @@ void endProgram(char *name)
   if(name != NULL)
   {
     cout << basename(name) << " v" << PACKAGE_VERSION <<": build a letter transducer from a dictionary" << endl;
-    cout << "USAGE: " << basename(name) << " [-avh] lr | rl dictionary_file output_file [acx_file]" << endl;
+    cout << "USAGE: " << basename(name) << " [-mavh] lr | rl dictionary_file output_file [acx_file]" << endl;
+    cout << "  -m:     keep morpheme boundaries" << endl;
     cout << "  -v:     set language variant" << endl;
     cout << "  -a:     set alternative (monodix)" << endl;
     cout << "  -l:     set left language variant (bidix)" << endl;
@@ -60,6 +61,7 @@ int main(int argc, char *argv[])
   char ttype = 'x';
   Compiler c;
   AttCompiler a;
+  c.setKeepBoundaries(false);
   c.setVerbose(false);
 
 #if HAVE_GETOPT_LONG
@@ -77,14 +79,15 @@ int main(int argc, char *argv[])
       {"var",       required_argument, 0, 'v'},
       {"var-left",  required_argument, 0, 'l'},
       {"var-right", required_argument, 0, 'r'},
+      {"keep-boundaries",      no_argument,       0, 'm'},
       {"help",      no_argument,       0, 'h'},
       {"verbose",   no_argument,       0, 'V'},
       {0, 0, 0, 0}
     };
 
-    int cnt=getopt_long(argc, argv, "a:v:l:r:hV", long_options, &option_index);
+    int cnt=getopt_long(argc, argv, "a:v:l:r:mhV", long_options, &option_index);
 #else
-    int cnt=getopt(argc, argv, "a:v:l:r:hV");
+    int cnt=getopt(argc, argv, "a:v:l:r:mhV");
 #endif
     if (cnt==-1)
       break;
@@ -107,6 +110,10 @@ int main(int argc, char *argv[])
       case 'r':
         vr = optarg;
         c.setVariantRightValue(vr);
+        break;
+
+      case 'm':
+        c.setKeepBoundaries(true);
         break;
 
       case 'V':

--- a/lttoolbox/lt_expand.cc
+++ b/lttoolbox/lt_expand.cc
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
 {
   FILE *input = NULL, *output = NULL;
   Expander e;
+  e.setKeepBoundaries(false);
 
 #if HAVE_GETOPT_LONG
   int option_index=0;
@@ -53,6 +54,7 @@ int main(int argc, char *argv[])
 #if HAVE_GETOPT_LONG
     static struct option long_options[] =
     {
+      {"keep-boundaries", no_argument, 0, 'm'},
       {"alt",       required_argument, 0, 'a'},
       {"var",       required_argument, 0, 'v'},
       {"var-left",  required_argument, 0, 'l'},
@@ -61,9 +63,9 @@ int main(int argc, char *argv[])
       {0, 0, 0, 0}
     };
 
-    int cnt=getopt_long(argc, argv, "a:v:l:r:h", long_options, &option_index);
+    int cnt=getopt_long(argc, argv, "a:v:l:r:mh", long_options, &option_index);
 #else
-    int cnt=getopt(argc, argv, "a:v:l:r:h");
+    int cnt=getopt(argc, argv, "a:v:l:r:mh");
 #endif
     if (cnt==-1)
       break;
@@ -80,6 +82,10 @@ int main(int argc, char *argv[])
 
       case 'l':
         e.setVariantLeftValue(optarg);
+        break;
+
+      case 'm':
+        e.setKeepBoundaries(true);
         break;
 
       case 'r':

--- a/lttoolbox/xsd/dix.xsd
+++ b/lttoolbox/xsd/dix.xsd
@@ -190,6 +190,7 @@
     <xs:complexType mixed="true">
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="a"/>
+        <xs:element ref="m"/>
         <xs:element ref="b"/>
         <xs:element ref="g"/>
         <xs:element ref="j"/>
@@ -217,6 +218,10 @@
   </xs:element>
   <!-- post-generator wake-up mark -->
   <xs:element name="b">
+    <xs:complexType/>
+  </xs:element>
+  <!-- morpheme boundary symbol -->
+  <xs:element name="m">
     <xs:complexType/>
   </xs:element>
   <!-- blank chars block mark -->

--- a/tests/data/morpheme-boundaries.dix
+++ b/tests/data/morpheme-boundaries.dix
@@ -1,0 +1,32 @@
+<dictionary>
+<alphabet></alphabet>
+<sdefs>
+  <sdef n="n"/><sdef n="sg"/><sdef n="pl"/>
+</sdefs>
+<pardefs>
+  <pardef n="wol/f__n">
+    <e><p><l>f</l><r>f<s n="n"/><s n="sg"/></r></p></e>
+    <e><p><l>v<m/>es</l><r>f<s n="n"/><s n="pl"/></r></p></e>
+  </pardef>
+  <pardef n="church__n">
+    <e><p><l></l><r><s n="n"/><s n="sg"/></r></p></e>
+    <e><p><l><m/>es</l><r><s n="n"/><s n="pl"/></r></p></e>
+  </pardef>
+  <pardef n="cat__n">
+    <e><p><l></l><r><s n="n"/><s n="sg"/></r></p></e>
+    <e><p><l><m/>s</l><r><s n="n"/><s n="pl"/></r></p></e>
+  </pardef>
+  <pardef n="ax/is__n">
+    <e><p><l><m/>is</l><r>is<s n="n"/><s n="sg"/></r></p></e>
+    <e><p><l><m/>es</l><r>is<s n="n"/><s n="pl"/></r></p></e>
+  </pardef>
+</pardefs>
+<section id="main" type="standard">
+  <e lm="cat"><i>cat</i><par n="cat__n"/></e>
+  <e lm="wolf"><i>wol</i><par n="wol/f__n"/></e>
+  <e lm="church"><i>church</i><par n="church__n"/></e>
+  <e lm="bat"><i>bat</i><par n="cat__n"/></e>
+  <e lm="rat"><i>rat</i><par n="cat__n"/></e>
+  <e lm="axis"><i>ax</i><par n="ax/is__n"/></e>
+</section>
+</dictionary>


### PR DESCRIPTION
The compiler and expander now allow `<m/>` inside `<l></l>` sides to represent morpheme boundaries. These are not compiled in, or printed by default, but can be with the `-m` or `--keep-boundaries` option. This closes #89.