### PR TITLE
Wordbound blanks parsed as normal blanks

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -672,7 +672,17 @@ FSTProcessor::readBilingual(FILE *input, FILE *output)
   }
   else if(val == L'[')
   {
-    fputws_unlocked(readFullBlock(input, L'[', L']').c_str(), output);
+    val = fgetwc_unlocked(input);
+    if(val == L'[')
+    {
+      fputws_unlocked(readWblank(input).c_str(), output);
+    }
+    else
+    {
+      ungetc(val, input);
+      fputws_unlocked(readFullBlock(input, L'[', L']').c_str(), output);
+    }
+    
     return readBilingual(input, output);
   }
 

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -305,7 +305,18 @@ FSTProcessor::readAnalysis(FILE *input)
         return altval;
 
       case L'[':
-        blankqueue.push(readFullBlock(input, L'[', L']'));
+        val = static_cast<wchar_t>(fgetwc_unlocked(input));
+        
+        if(val == L'[')
+        {
+          blankqueue.push(readWblank(input));
+        }
+        else
+        {
+          ungetc(val, input);
+          blankqueue.push(readFullBlock(input, L'[', L']'));
+        }
+        
         input_buffer.add(static_cast<int>(L' '));
         return static_cast<int>(L' ');
 
@@ -356,7 +367,18 @@ FSTProcessor::readTMAnalysis(FILE *input)
         return altval;
 
       case L'[':
-        blankqueue.push(readFullBlock(input, L'[', L']'));
+        val = static_cast<wchar_t>(fgetwc_unlocked(input));
+        
+        if(val == L'[')
+        {
+          blankqueue.push(readWblank(input));
+        }
+        else
+        {
+          ungetc(val, input);
+          blankqueue.push(readFullBlock(input, L'[', L']'));
+        }
+        
         input_buffer.add(static_cast<int>(L' '));
         isLastBlankTM = true;
         return static_cast<int>(L' ');
@@ -425,7 +447,18 @@ FSTProcessor::readPostgeneration(FILE *input)
       return altval;
 
     case L'[':
-      blankqueue.push(readFullBlock(input, L'[', L']'));
+      val = static_cast<wchar_t>(fgetwc_unlocked(input));
+      
+      if(val == L'[')
+      {
+        blankqueue.push(readWblank(input));
+      }
+      else
+      {
+        ungetc(val, input);
+        blankqueue.push(readFullBlock(input, L'[', L']'));
+      }
+      
       input_buffer.add(static_cast<int>(L' '));
       return static_cast<int>(L' ');
 

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -517,72 +517,17 @@ FSTProcessor::readGeneration(FILE *input, FILE *output)
     wstring cad = L"";
     cad += static_cast<wchar_t>(val);
       
-    bool isSecondaryTag = false;
-      
     while((val = fgetwc_unlocked(input)) != L'>')
     {
       if(feof(input))
       {
         streamError();
       }
-      if(val == L':')
-      {
-        isSecondaryTag = true;
-        break;
-      }
       cad += static_cast<wchar_t>(val);
     }
     cad += static_cast<wchar_t>(val);
     
-    if(isSecondaryTag)
-    {
-      while(true)
-      {
-        val = fgetwc_unlocked(input);
-          
-        if(feof(input))
-        {
-          streamError();
-        }
-        
-        if(val == L'\\')
-        {
-          val = fgetwc_unlocked(input);
-          continue;
-        }
-        
-        if(isSecondaryTag)
-        {
-          if(val == L'>')
-          {
-            isSecondaryTag = false;
-          }
-        }
-        else
-        {
-          if(val == L'<')
-          {
-            isSecondaryTag = true;
-          }
-          else if(val == L'$')
-          {
-              break;
-          }
-          else
-          {
-            return static_cast<int>(val);
-          }
-        }
-      }
-        
-      outOfWord = true;
-      return static_cast<int>(L'$');
-    }
-    else
-    {
-      return alphabet(cad);
-    }
-    
+    return alphabet(cad);
   }
   else if(val == L'[')
   {

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -251,6 +251,12 @@ private:
    * @param delim1 the delimiter of the end of the sequence
    */
   wstring readFullBlock(FILE *input, wchar_t const delim1, wchar_t const delim2);
+  
+  /**
+   * Reads a wordbound blank from the stream input
+   * @param input the stream being read
+   */
+  wstring readWblank(FILE *input);
 
   /**
    * Returns true if the character code is identified as alphabetic

--- a/tests/data/wordbound-blank.dix
+++ b/tests/data/wordbound-blank.dix
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+  <sdefs>
+    <sdef n="vblex"/>
+    <sdef n="inf"/>
+    <sdef n="pr"/>
+    <sdef n="prn"/>
+    <sdef n="np"/>
+    <sdef n="sent"/>
+  </sdefs>
+  <pardefs>
+  </pardefs>
+
+  <section id="main" type="standard">
+    <e><p><l>legge</l> <r>legge<s n="vblex"/><s n="inf"/></r></p></e>
+    <e><p><l>legge<b/>opp<b/>til</l> <r>legge<g><b/>opp<b/>til<s n="vblex"/><s n="inf"/></g></r></p></e>
+    <e><p><l>opp</l> <r>opp<s n="pr"/></r></p></e>
+
+    <e><p><l>legge<b/>seg<b/>opp<b/>til</l> <r>legge<g><b/>seg<b/>opp<b/>til<s n="vblex"/><s n="inf"/></g></r></p></e>
+    <e><p><l>seg</l> <r>seg<s n="prn"/></r></p></e>
+
+    <e><p><l>St.<b/>Petersburg</l> <r>St.<b/>Petersburg<s n="np"/></r></p></e>
+    <e><p><l>X<b/>y</l> <r>X<b/>y<s n="np"/></r></p></e>
+    <e><p><l>F</l> <r>F<s n="np"/></r></p></e>
+    <e><p><l>G</l> <r>G<s n="np"/></r></p></e>
+  </section>
+
+  <section id="final" type="inconditional">
+    <e><p><l>.</l> <r>.<s n="sent"/></r></p></e>
+  </section>
+
+</dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -130,5 +130,14 @@ class CatMultipleFstsTransducer(unittest.TestCase, ProcTest):
     inputs = ["cat", "cats"]
     expectedOutputs = ["^cat/cat+n/cat+v$", "^cats/cat+n+<pl>$"]
 
+class WordboundBlankAnalysisTest(unittest.TestCase, ProcTest):
+    procdix = "data/gardenpath-mwe.dix"
+    inputs          = ["x  [[t:i:123456]]opp.",
+                        "[[t:b:456123; t:i:90hfbn]]legge  [[t:s:xyz789]]opp  opp [[t:b:abc124]]x opp.",
+                       ]
+    expectedOutputs = ["^x/*x$  [[t:i:123456]]^opp/opp<pr>$^./.<sent>$",
+                        "[[t:b:456123; t:i:90hfbn]]^legge/legge<vblex><inf>$  [[t:s:xyz789]]^opp/opp<pr>$  ^opp/opp<pr>$ [[t:b:abc124]]^x/*x$ ^opp/opp<pr>$^./.<sent>$",
+                       ]
+
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *


### PR DESCRIPTION
- Parsing wordbound blanks as normal blanks for analysis, generation, biltrans, postgeneration.
- Also removed unused code for secondary tags.
- Added a test for wordbound blank analysis.