### PR TITLE
Wordbound blank handling in post generation

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -298,7 +298,7 @@ FSTProcessor::wblankPostGen(FILE *input, FILE *output)
 
       if(c == L']')
       {
-        int resultlen = result.length();
+        int resultlen = result.size();
         if(result[resultlen-5] == '[' && result[resultlen-4] == '[' && result[resultlen-3] == '/') //ending blank [[/]]
         {
           fputws(result.c_str(), output);
@@ -805,7 +805,7 @@ FSTProcessor::flushBlanks(FILE *output)
 void
 FSTProcessor::flushWblanks(FILE *output)
 {
-  for(size_t i = wblankqueue.size(); i > 0; i--)
+  while(wblankqueue.size() > 0)
   {
     fputws_unlocked(wblankqueue.front().c_str(), output);
     wblankqueue.pop();
@@ -818,7 +818,7 @@ FSTProcessor::combineWblanks()
   wstring final_wblank;
   wstring last_wblank = L"";
   
-  for(size_t i = wblankqueue.size(); i > 0; i--)
+  while(wblankqueue.size() > 0)
   {
     if(wblankqueue.front().compare(L"[[/]]") == 0)
     {
@@ -826,12 +826,12 @@ FSTProcessor::combineWblanks()
       {
         final_wblank += L"[[";
       }
-      else if(final_wblank.length() > 2)
+      else if(final_wblank.size() > 2)
       {
         final_wblank += L"; ";
       }
       
-      final_wblank += last_wblank.substr(2,last_wblank.length()-4); //add wblank without brackets [[..]]
+      final_wblank += last_wblank.substr(2,last_wblank.size()-4); //add wblank without brackets [[..]]
       last_wblank.clear();
     }
     else

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -2250,6 +2250,11 @@ FSTProcessor::postgeneration(FILE *input, FILE *output)
       }
       else
       {
+        if(!need_end_wblank)
+        {
+          flushWblanks(output);
+        }
+        
         if(isEscaped(val))
         {
           fputwc_unlocked(L'\\', output);
@@ -2262,7 +2267,6 @@ FSTProcessor::postgeneration(FILE *input, FILE *output)
           need_end_wblank = false;
         }
       }
-      flushWblanks(output);
     }
     else
     {

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -820,16 +820,17 @@ FSTProcessor::combineWblanks()
   
   for(size_t i = wblankqueue.size(); i > 0; i--)
   {
-    if(final_wblank.empty())
-    {
-      final_wblank += L"[[";
-    }
     if(wblankqueue.front().compare(L"[[/]]") == 0)
     {
-      if(final_wblank.length() > 2)
+      if(final_wblank.empty())
+      {
+        final_wblank += L"[[";
+      }
+      else if(final_wblank.length() > 2)
       {
         final_wblank += L"; ";
       }
+      
       final_wblank += last_wblank.substr(2,last_wblank.length()-4); //add wblank without brackets [[..]]
       last_wblank.clear();
     }
@@ -2239,17 +2240,29 @@ FSTProcessor::postgeneration(FILE *input, FILE *output)
     {
       if(iswspace(val))
       {
+        if(need_end_wblank)
+        {
+          fputws_unlocked(L"[[/]]", output);
+          need_end_wblank = false;
+        }
+        
         printSpace(val, output);
       }
       else
       {
-        flushWblanks(output);
         if(isEscaped(val))
         {
           fputwc_unlocked(L'\\', output);
         }
         fputwc_unlocked(val, output);
+        
+        if(need_end_wblank)
+        {
+          fputws_unlocked(L"[[/]]", output);
+          need_end_wblank = false;
+        }
       }
+      flushWblanks(output);
     }
     else
     {
@@ -2378,12 +2391,6 @@ FSTProcessor::postgeneration(FILE *input, FILE *output)
           }
         }
         
-        if(need_end_wblank)
-        {
-          fputws_unlocked(L"[[/]]", output);
-          need_end_wblank = false;
-        }
-
         current_state = initial_state;
         lf = L"";
         sf = L"";

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -104,6 +104,11 @@ private:
   queue<wstring> blankqueue;
 
   /**
+   * Queue of wordbound blanks, used in reading methods
+   */
+  queue<wstring> wblankqueue;
+  
+  /**
    * Set of characters being considered alphabetics
    */
   set<wchar_t> alphabetic_chars;
@@ -226,6 +231,21 @@ private:
    * Output no more than 'N' number of weighted analyses
    */
   int maxAnalyses;
+  
+  /**
+   * True if a wblank block ([[..]]xyz[[/]]) was just read
+   */
+  bool is_wblank;
+  
+  /**
+   * True if skip_mode is false and need to collect wblanks
+   */
+  bool collect_wblanks;
+  
+  /**
+   * True if a wblank has been processed for postgen and we need an ending wblank
+   */
+  bool need_end_wblank;
 
   /**
    * Output no more than 'N' best weight classes
@@ -257,6 +277,14 @@ private:
    * @param input the stream being read
    */
   wstring readWblank(FILE *input);
+  
+  /**
+   * Reads a wordbound blank (opening blank to closing blank) from the stream input -> [[...]]xyz[[/]]
+   * @param input the stream being read
+   * @param output the stream to write on
+   * @return true if the word enclosed by the wordbound blank has a ~ for postgeneration activation
+   */
+  bool wblankPostGen(FILE *input, FILE *output);
 
   /**
    * Returns true if the character code is identified as alphabetic
@@ -282,6 +310,7 @@ private:
   /**
    * Read text from stream (decomposition version)
    * @param input the stream to read
+   * @param output the stream to write on
    * @return the next symbol in the stream
    */
   int readDecomposition(FILE *input, FILE *output);
@@ -289,13 +318,15 @@ private:
   /**
    * Read text from stream (postgeneration version)
    * @param input the stream to read
+   * @param output the stream to write on
    * @return the next symbol in the stream
    */
-  int readPostgeneration(FILE *input);
+  int readPostgeneration(FILE *input, FILE *output);
 
   /**
    * Read text from stream (generation version)
    * @param input the stream to read
+   * @param output the stream being written to
    * @return the next symbol in the stream
    */
   int readGeneration(FILE *input, FILE *output);
@@ -303,6 +334,7 @@ private:
   /**
    * Read text from stream (biltrans version)
    * @param input the stream to read
+   * @param output the stream to write on
    * @return the queue of 0-symbols, and the next symbol in the stream
    */
   pair<wstring, int> readBilingual(FILE *input, FILE *output);
@@ -319,6 +351,18 @@ private:
    * @param output stream to write blanks
    */
   void flushBlanks(FILE *output);
+  
+  /**
+   * Flush all the wordbound blanks remaining in the current process
+   * @param output stream to write blanks
+   */
+  void flushWblanks(FILE *output);
+  
+  /**
+   * Combine wordbound blanks in the queue and return them
+   * @return final wblank string
+  */
+  wstring combineWblanks();
 
   /**
    * Calculate the initial state of parsing

--- a/tests/data/postgen.dix
+++ b/tests/data/postgen.dix
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet/>
+  <sdefs>
+    <sdef n="test"/>
+  </sdefs>
+
+  <pardefs>
+    
+    <pardef n="el">
+
+      <e>
+        <p>
+          <l>el<b/></l>
+          <r>l<b/></r>
+        </p>
+      </e>
+      <e>
+        <p>
+          <l>el</l>
+          <r>l</r>
+        </p>
+      </e>
+    </pardef>
+
+   <pardef n="le">
+      <e>
+        <p>
+          <l>la<b/></l>
+          <r>se<b/>la<b/></r>
+        </p>
+      </e>
+      <e>
+        <p>
+          <l>las<b/></l>
+          <r>se<b/>las<b/></r>
+        </p>
+      </e>
+      <e>
+        <p>
+          <l>lo<b/></l>
+          <r>se<b/>lo<b/></r>
+        </p>
+      </e>
+      <e>
+        <p>
+          <l>los<b/></l>
+          <r>se<b/>los<b/></r>
+        </p>
+      </e>
+    </pardef>
+
+
+  </pardefs>
+
+  <section id="main" type="standard">
+
+     <e>
+        <p>
+          <l><a/>de<b/></l>
+          <r>de</r>
+        </p>
+        <par n="el"/>
+      </e>
+
+      <e>
+        <p>
+          <l><a/>o<b/>ho</l>
+          <r>u<b/>ho</r>
+        </p>
+      </e>
+
+      <e>
+        <p>
+          <l><a/>le<b/></l>
+          <r/>
+        </p>
+        <par n="le"/>
+      </e>
+
+      <e>
+        <p>
+          <l><a/>les<b/></l>
+          <r>le<b/>pe<b/>test<b/></r>
+        </p>
+      </e>
+
+  </section>
+
+</dictionary>
+

--- a/tests/data/postgen.dix
+++ b/tests/data/postgen.dix
@@ -85,6 +85,13 @@
         </p>
       </e>
 
+      <e>
+        <p>
+          <l><a/>les<b/>pes<b/></l>
+          <r>les<b/>pes<b/>test<b/></r>
+        </p>
+      </e>
+
   </section>
 
 </dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -139,5 +139,53 @@ class WordboundBlankAnalysisTest(unittest.TestCase, ProcTest):
                         "[[t:b:456123; t:i:90hfbn]]^legge/legge<vblex><inf>$  [[t:s:xyz789]]^opp/opp<pr>$  ^opp/opp<pr>$ [[t:b:abc124]]^x/*x$ ^opp/opp<pr>$^./.<sent>$",
                        ]
 
+class PostgenerationBasicTest(unittest.TestCase, ProcTest):
+    procdix = "data/postgen.dix"
+    procflags = ["-p", "-z"]
+    inputs          = [ "xyz ejemplo ~o ho nombre.",
+                        "xyz ~le la pelota.",
+                        "El perro ~de el amigo.",
+                        "abc ~les testword"]
+    expectedOutputs = [ "xyz ejemplo u ho nombre.",
+                        "xyz se la pelota.", 
+                        "El perro del amigo.", 
+                        "abc le pe test testword"]
+
+class PostgenerationWordboundBlankTest(unittest.TestCase, ProcTest):
+    procdix = "data/postgen.dix"
+    procflags = ["-p", "-z"]
+    inputs          = [ "xyz ejemplo [[t:i:123456]]~o[[/]] [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+                        "xyz ejemplo [[t:b:poim230]]~o[[/]] ho [[t:i:mnbj203]]nombre[[/]].",
+                        "xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+                        "xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] ~le la [[t:b:iopmnb]]nombre[[/]].",
+                        "xyz ejemplo [[t:i:1235gb]]~o[[/]] [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:i4x56fb]]~le[[/]] la nombre.",
+                        "xyz [[t:i:123456]]~le[[/]] [[t:b:123gfv]]la[[/]] pelota.",
+                        "xyz ~le [[t:b:123gfv]]la[[/]] pelota.",
+                        "xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] ~le [[t:b:io1245b]]la[[/]] [[t:b:iopmnb]]nombre[[/]].",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:h5lVhA]]El[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]perro[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:npAFwg]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]~de[[/]] el [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] ~de [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] ~de el [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:abc123; t:i:123456]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] testword[[/]]"]
+
+    expectedOutputs = [ "xyz ejemplo [[t:i:123456; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+                        "xyz ejemplo [[t:b:poim230]]u ho[[/]] [[t:i:mnbj203]]nombre[[/]].",
+                        "xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+                        "xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] se la [[t:b:iopmnb]]nombre[[/]].",
+                        "xyz ejemplo [[t:i:1235gb; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:i4x56fb]]se la[[/]] nombre.",
+                        "xyz [[t:i:123456; t:b:123gfv]]se la[[/]] pelota.",
+                        "xyz [[t:b:123gfv]]se la[[/]] pelota.",
+                        "xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:io1245b]]se la[[/]] [[t:b:iopmnb]]nombre[[/]].",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:h5lVhA]]El[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]perro[[/]] [[t:b:Z9eiLA; t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:npAFwg]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] del [[t:i:wSM6RQ]]amigo[[/]][]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] le pe test [[t:b:abc123; t:i:123456]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] testword[[/]]"]
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -169,7 +169,10 @@ class PostgenerationWordboundBlankTest(unittest.TestCase, ProcTest):
                         "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] ~de el [[t:i:wSM6RQ]]amigo[[/]][]",
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
                         "[[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:abc123; t:i:123456]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] testword[[/]]"]
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]"]
 
     expectedOutputs = [ "xyz ejemplo [[t:i:123456; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
                         "xyz ejemplo [[t:b:poim230]]u ho[[/]] [[t:i:mnbj203]]nombre[[/]].",
@@ -186,6 +189,9 @@ class PostgenerationWordboundBlankTest(unittest.TestCase, ProcTest):
                         "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] del [[t:i:wSM6RQ]]amigo[[/]][]",
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
                         "[[t:b:Z9eiLA]]abc[[/]] le pe test [[t:b:abc123; t:i:123456]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] testword[[/]]"]
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456; t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]"]
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *


### PR DESCRIPTION
- Wordbound blanks merge when words merge.
- Wordbound blanks apply to all output words when output of postgen rule are more than input words.
- No regression for postgeneration without wordbound blanks.
- Lots of tests added.

Example:
Input:
```
[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:123445]]el[[/]] [[t:i:wSM6RQ]]amigo[[/]][]
```

Output:
```
[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA; t:b:123445]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]
```

For more examples see ``PostgenerationWordboundBlankTest`` in ``lttoolbox/tests/lt_proc/__init__.py``.