### PR TITLE
Fix #107 – postgenerator fails when ~ in middle of wblanked word

### DIFF
--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -359,7 +359,15 @@ private:
   void flushWblanks(FILE *output);
 
   /**
-   * Combine wordbound blanks in the queue and return them
+   * Combine wordbound blanks in the queue and return them.
+   *
+   * May pop from 'wblankqueue' and set 'need_end_wblank' to true.
+   *
+   * If 'wblankqueue' (see which) is empty, we get an empty string,
+   * otherwise we return a semicolon-separated combination of opening
+   * wblanks in the queue. If there is only a closing wblank, we just
+   * set need_end_wblank.
+   *
    * @return final wblank string
   */
   wstring combineWblanks();

--- a/tests/data/postgen.dix
+++ b/tests/data/postgen.dix
@@ -92,6 +92,8 @@
         </p>
       </e>
 
+    <e><p><l><a/>sss</l><r>ss</r></p></e>
+
   </section>
 
 </dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -173,7 +173,11 @@ class PostgenerationWordboundBlankTest(ProcTest):
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]"]
+                        "[[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:text:NaNaNa]]pla~ss[[/]]",
+                        "[[t:text:NaNaNa]]pla~sss[[/]]",
+                        "[[t:text:NaNaNa]]pla~ssar[[/]]",
+                        "[[t:text:NaNaNa]]pla~sssar[[/]]"]
 
     expectedOutputs = [ "xyz ejemplo [[t:i:123456; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
                         "xyz ejemplo [[t:b:poim230]]u ho[[/]] [[t:i:mnbj203]]nombre[[/]].",
@@ -193,7 +197,11 @@ class PostgenerationWordboundBlankTest(ProcTest):
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
                         "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456; t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]"]
+                        "[[t:b:Z9eiLA]]abc[[/]] [[t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+                        "[[t:text:NaNaNa]]plass[[/]]",
+                        "[[t:text:NaNaNa]]plass[[/]]",
+                        "[[t:text:NaNaNa]]plassar[[/]]",
+                        "[[t:text:NaNaNa]]plassar[[/]]"]
 
 
 class PostgenerationWordboundBlankEscapingTest(ProcTest):


### PR DESCRIPTION
There was already support for `[[w:text:foo]]~zzy[[/]] ` but not for
`[[w:text:foo]]xy~zzy[[/]]`

This change should keep the old feature of moving wblank-start after
the post-generated part of `[[w:text:foo]]~zzy[[/]] ` (so if there was
a rule turning `~z` into Z we get `Z[[w:text:foo]]zy[[/]]`), but if the
wake-up-mark `~` is seen later in the wblank, it stays surrounded, so
`[[w:text:foo]]xy~zzy[[/]]` turns into `[[w:text:foo]]xyZzy[[/]]`.

 plus tests for https://github.com/apertium/lttoolbox/issues/107 

 plus necessary changes for combineWblanks (can now get called when no
    opening wblanks in queue)


(Alternatively I've done a rebase on the icu-branch in case that's going to be merged now-ish https://github.com/apertium/lttoolbox/tree/107-pgenblanks , but I see that branch fails on (unrelated) att-compiler tests)