### PR TITLE
Fix #120 leak in State::apply (and variants thereof)

### DIFF
--- a/lttoolbox/state.cc
+++ b/lttoolbox/state.cc
@@ -150,13 +150,13 @@ State::apply_into_override(vector<TNodeState>* new_state, int const input, int c
 void
 State::apply(int const input)
 {
-  vector<TNodeState> new_state;
   if(input == 0)
   {
-    state = new_state;
+    destroy();
     return;
   }
 
+  vector<TNodeState> new_state;
   for(size_t i = 0, limit = state.size(); i != limit; i++)
   {
     apply_into(&new_state, input, i, false);
@@ -169,14 +169,13 @@ State::apply(int const input)
 void
 State::apply_override(int const input, int const old_sym, int const new_sym)
 {
-  vector<TNodeState> new_state;
   if(input == 0 || old_sym == 0)
   {
-    state = new_state;
+    destroy();
     return;
   }
 
-
+  vector<TNodeState> new_state;
   for(size_t i = 0, limit = state.size(); i != limit; i++)
   {
     apply_into_override(&new_state, input, old_sym, new_sym, i, false);
@@ -196,14 +195,13 @@ State::apply_override(int const input, int const alt, int const old_sym, int con
     return;
   }
 
-  vector<TNodeState> new_state;
   if(input == 0 || old_sym == 0)
   {
-    state = new_state;
+    destroy();
     return;
   }
 
-
+  vector<TNodeState> new_state;
   for(size_t i = 0, limit = state.size(); i != limit; i++)
   {
     apply_into_override(&new_state, input, old_sym, new_sym, i, false);
@@ -218,13 +216,13 @@ State::apply_override(int const input, int const alt, int const old_sym, int con
 void
 State::apply(int const input, int const alt)
 {
-  vector<TNodeState> new_state;
   if(input == 0 || alt == 0)
   {
-    state = new_state;
+    destroy();
     return;
   }
 
+  vector<TNodeState> new_state;
   if(input == alt)
   {
     apply(input);
@@ -244,14 +242,13 @@ State::apply(int const input, int const alt)
 void
 State::apply_careful(int const input, int const alt)
 {
-  vector<TNodeState> new_state;
   if(input == 0 || alt == 0)
   {
-    state = new_state;
+    destroy();
     return;
   }
 
-
+  vector<TNodeState> new_state;
   for(size_t i = 0, limit = state.size(); i != limit; i++)
   {
     if(!apply_into(&new_state, input, i, false))


### PR DESCRIPTION
#120

``` shell
$ echo '^ja<ij><copytags>$' | valgrind --leak-check=full ~/PREFIX/lttoolbox/bin/lt-proc -b ../apertium-nno-nob/nob-nno.autobil.bin
==776548== Memcheck, a memory error detector
==776548== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==776548== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==776548== Command: /home/unhammer/PREFIX/lttoolbox/bin/lt-proc -b ../apertium-nno-nob/nob-nno.autobil.bin
==776548==
^ja<ij><copytags>/ja<ij><copytags>$
==776548==
==776548== HEAP SUMMARY:
==776548==     in use at exit: 7,826 bytes in 31 blocks
==776548==   total heap usage: 906,656 allocs, 906,625 frees, 26,955,352 bytes allocated
==776548==
==776548== LEAK SUMMARY:
==776548==    definitely lost: 0 bytes in 0 blocks
==776548==    indirectly lost: 0 bytes in 0 blocks
==776548==      possibly lost: 0 bytes in 0 blocks
==776548==    still reachable: 7,826 bytes in 31 blocks
==776548==         suppressed: 0 bytes in 0 blocks
==776548== Reachable blocks (those to which a pointer was found) are not shown.
==776548== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==776548==
==776548== For lists of detected and suppressed errors, rerun with: -s
==776548== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

and stays constant at 50M RES for the whole 663710 line corpus