### PR TITLE
Fix lt-expand duplication

### DIFF
--- a/lttoolbox/expander.cc
+++ b/lttoolbox/expander.cc
@@ -475,15 +475,9 @@ Expander::procEntry(UFILE* output)
           items_rl.insert(items_rl.end(), items.begin(), items.end());
         }
 
-        EntList aux_lr = items_lr;
-        EntList aux_rl = items_rl;
-        append(aux_lr, paradigm[p]);
-        append(aux_rl, paradigm[p]);
         append(items_lr, paradigm_lr[p]);
         append(items_rl, paradigm_rl[p]);
         append(items, paradigm[p]);
-        items_rl.insert(items_rl.end(), aux_rl.begin(), aux_rl.end());
-        items_lr.insert(items_lr.end(), aux_lr.begin(), aux_lr.end());
       }
     }
     else if(name == Compiler::COMPILER_ENTRY_ELEM && type == XML_READER_TYPE_END_ELEMENT)


### PR DESCRIPTION
This part of code seems to be duplicating entries when there are direction restrictions in paradigms. Removing it solves the issue without apparent side effects (I have run tests on apertium-cat, apertium-eng and apertium-ron).

I have no deep knowledge of lttoolbox, so someone should probably check I am not breaking anything else. Thanks!

Fixes #125