### PR TITLE
Use character iterator when looping codepoints for isAlphabetic

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -3358,13 +3358,15 @@ FSTProcessor::getNullFlush()
 size_t
 FSTProcessor::firstNotAlpha(UString const &sf)
 {
-  for(size_t i = 0, limit = sf.size(); i < limit; i++)
-  {
-    if(!isAlphabetic(sf[i]))
+  UCharCharacterIterator it = UCharCharacterIterator(sf.c_str(), sf.size());
+  size_t i = 0;
+  while (it.hasNext()) {
+    UChar32 c = it.next32PostInc();
+    if(!isAlphabetic(c))
     {
       return i;
     }
+    i += c > UINT16_MAX ? 2 : 1;
   }
-
   return UString::npos;
 }

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -19,6 +19,7 @@
 #define _FSTPROCESSOR_
 
 #include <lttoolbox/ustring.h>
+#include <unicode/uchriter.h>
 #include <lttoolbox/alphabet.h>
 #include <lttoolbox/buffer.h>
 #include <lttoolbox/my_stdio.h>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -229,23 +229,30 @@ class SpaceAtEOF(ProcTest):
 
 
 class NonBMPDixTest(ProcTest):
-	procdix = "data/non-bmp.dix"
-	inputs = ['𐅁𐅃𐅅', '𐅂𐅄𐅆']
-	expectedOutputs = ['^𐅁𐅃𐅅/𐅁𐅃𐅅<num>$', '^𐅂𐅄𐅆/𐅂𐅄𐅆<num>$']
+    procdix = "data/non-bmp.dix"
+    inputs = ['𐅁𐅃𐅅', '𐅂𐅄𐅆']
+    expectedOutputs = ['^𐅁𐅃𐅅/𐅁𐅃𐅅<num>$', '^𐅂𐅄𐅆/𐅂𐅄𐅆<num>$']
 
 
 class NonBMPATTTest(ProcTest):
-	procdix = "data/non-bmp.att"
-	inputs = ['𐅁𐅃𐅅', '𐅂𐅄𐅆']
-	expectedOutputs = ['^𐅁𐅃𐅅/𐅁𐅃𐅅<num>$', '^𐅂𐅄𐅆/𐅂𐅄𐅆<num>$']
+    procdix = "data/non-bmp.att"
+    inputs = ['𐅁𐅃𐅅', '𐅂𐅄𐅆']
+    expectedOutputs = ['^𐅁𐅃𐅅/𐅁𐅃𐅅<num>$', '^𐅂𐅄𐅆/𐅂𐅄𐅆<num>$']
 
 
 class NonBMPGeneratorTest(ProcTest):
-	procdix = "data/non-bmp.att"
-	inputs = ['^𐅁𐅃𐅅<num>$', '^𐅂𐅄𐅆<num>$']
-	expectedOutputs = ['𐅁𐅃𐅅', '𐅂𐅄𐅆']
-	procflags = ['-z', '-g']
-	procdir = "rl"
+    procdix = "data/non-bmp.att"
+    inputs = ['^𐅁𐅃𐅅<num>$', '^𐅂𐅄𐅆<num>$']
+    expectedOutputs = ['𐅁𐅃𐅅', '𐅂𐅄𐅆']
+    procflags = ['-z', '-g']
+    procdir = "rl"
+
+
+class AlphabeticMultibyteTest(ProcTest):
+    procdix = "data/minimal-mono.dix"
+    inputs = ["𝜊"]  # code point >65535, needs two bytes in utf-8, isAlphabetic
+    expectedOutputs = ["^𝜊/*𝜊$"]
+
 
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *


### PR DESCRIPTION
old code was checking 16-bit code units, thus giving wrong values for
isAlphabetic (which expects a full code point)

Fixes #127

(Related: https://github.com/apertium/apertium/pull/152)