### PR TITLE
lt-comp -j: minimise sections in parallel, slice ⅓ off compilation time

### DIFF
--- a/lttoolbox/compiler.h
+++ b/lttoolbox/compiler.h
@@ -23,6 +23,7 @@
 #include <lttoolbox/transducer.h>
 #include <lttoolbox/ustring.h>
 
+#include <thread>
 #include <map>
 #include <string>
 #include <set>
@@ -111,6 +112,11 @@ private:
    * Maintain morpheme boundaries
    */
   bool keep_boundaries = false;
+
+  /**
+   * Allow parallel minimisation jobs
+   */
+  bool jobs = false;
 
 
   /**
@@ -371,6 +377,11 @@ public:
    * Set keep morpheme boundaries
    */
   void setKeepBoundaries(bool keep_boundaries = false);
+
+  /**
+   * Set whether to allow parallel minimisation jobs
+   */
+  void setJobs(bool jobs = false);
 
   /**
    * Set verbose output

--- a/lttoolbox/lt_comp.cc
+++ b/lttoolbox/lt_comp.cc
@@ -41,7 +41,7 @@ void endProgram(char *name)
   if(name != NULL)
   {
     cout << basename(name) << " v" << PACKAGE_VERSION <<": build a letter transducer from a dictionary" << endl;
-    cout << "USAGE: " << basename(name) << " [-mavhlr] lr | rl dictionary_file output_file [acx_file]" << endl;
+    cout << "USAGE: " << basename(name) << " [-hmvalrHSj] lr | rl dictionary_file output_file [acx_file]" << endl;
 #if HAVE_GETOPT_LONG
     cout << "  -m, --keep-boundaries:     keep morpheme boundaries" << endl;
     cout << "  -v, --var:                 set language variant" << endl;
@@ -50,6 +50,7 @@ void endProgram(char *name)
     cout << "  -r, --var-right:           set right language variant (bidix)" << endl;
     cout << "  -H, --hfst:                expect HFST symbols" << endl;
     cout << "  -S, --no-split:            don't attempt to split into word and punctuation transducers" << endl;
+    cout << "  -j, --jobs:                use one cpu core per section when minimising" << endl;
 #else
     cout << "  -m:     keep morpheme boundaries" << endl;
     cout << "  -v:     set language variant" << endl;
@@ -58,6 +59,7 @@ void endProgram(char *name)
     cout << "  -r:     set right language variant (bidix)" << endl;
     cout << "  -H:     expect HFST symbols" << endl;
     cout << "  -S:     don't attempt to split into word and punctuation transducers" << endl;
+    cout << "  -j:     use one cpu core per section when minimising" << endl;
 #endif
     cout << "Modes:" << endl;
     cout << "  lr:     left-to-right compilation" << endl;
@@ -97,10 +99,11 @@ int main(int argc, char *argv[])
       {"no-split",  no_argument,       0, 'S'},
       {"help",      no_argument,       0, 'h'},
       {"verbose",   no_argument,       0, 'V'},
+      {"jobs",      no_argument,       0, 'j'},
       {0, 0, 0, 0}
     };
 
-    int cnt=getopt_long(argc, argv, "a:v:l:r:mHShV", long_options, &option_index);
+    int cnt=getopt_long(argc, argv, "a:v:l:r:mHShVj", long_options, &option_index);
 #else
     int cnt=getopt(argc, argv, "a:v:l:r:mHShV");
 #endif
@@ -137,6 +140,10 @@ int main(int argc, char *argv[])
 
       case 'S':
         a.setSplitting(false);
+        break;
+
+      case 'j':
+        c.setJobs(true);
         break;
 
       case 'V':

--- a/lttoolbox/lt_comp.cc
+++ b/lttoolbox/lt_comp.cc
@@ -157,6 +157,10 @@ int main(int argc, char *argv[])
     }
   }
 
+  if(const char* jobs_env = std::getenv("LT_JOBS")) {
+    c.setJobs(true);
+  }
+
   string opc;
   string infile;
   string outfile;


### PR DESCRIPTION
Basically does

    for fst in sections; do minimise fst & done; wait

Testing nob.dix with four sections of about the same size and four
cores gives 25s → 16s wall time.

For now only active when lt-comp -j since memory usage increases (from
410M to 684M RES with the above dix).

(There is no max thread count either, but dix files typically don't
have more than two or three sections, no need to complicate the code
before it becomes an issue.)