### PR TITLE
Automatically create new sections after 50k entries when -j

### DIFF
--- a/lttoolbox/compiler.cc
+++ b/lttoolbox/compiler.cc
@@ -925,10 +925,17 @@ Compiler::procNode()
   }
   else if(name == COMPILER_ENTRY_ELEM)
   {
+    if(current_paradigm.empty()) {
+      n_section_entries++;
+      if(max_section_entries >0 && n_section_entries % max_section_entries == 0) {
+        current_section = u"+" + current_section; // would be invalid as xml id -- this way we won't clobber existing names
+      }
+    }
     procEntry();
   }
   else if(name == COMPILER_SECTION_ELEM)
   {
+    n_section_entries = 0;
     procSection();
   }
   else if(name== COMPILER_COMMENT_NODE)
@@ -993,6 +1000,12 @@ void
 Compiler::setJobs(bool j)
 {
   jobs = j;
+}
+
+void
+Compiler::setMaxSectionEntries(size_t m)
+{
+  max_section_entries = m;
 }
 
 void

--- a/lttoolbox/compiler.h
+++ b/lttoolbox/compiler.h
@@ -78,6 +78,17 @@ private:
   UString current_paradigm;
 
   /**
+   * The number of top-level entries read in this section.
+   */
+  size_t n_section_entries = 0;
+
+  /**
+   * The maximum number of top-level entries per section.
+   * If 0, no limit.
+   */
+  size_t max_section_entries = 0;
+
+  /**
    * The dictionary section being compiled
    */
   UString current_section;
@@ -381,7 +392,12 @@ public:
   /**
    * Set whether to allow parallel minimisation jobs
    */
-  void setJobs(bool jobs = false);
+  void setJobs(bool jobs);
+
+  /**
+   * Set how many top-level entries to allow in a section before starting a new one automatically
+   */
+  void setMaxSectionEntries(size_t m);
 
   /**
    * Set verbose output

--- a/lttoolbox/lt-comp.1
+++ b/lttoolbox/lt-comp.1
@@ -61,6 +61,14 @@ Keep any morpheme boundaries defined by the '<m/>' symbol
 expect HFST symbols
 .It Fl S , Fl Fl no-split
 don't attempt to split into word and punctuation transducers
+.It Fl j , Fl Fl jobs
+Parallelise minimisation by using one cpu core per section. By
+default, this also creates a new section after 50.000 entries. You can
+override this number by setting the environment variable
+LT_MAX_SECTION_ENTRIES to some number. If set to 0, sections are never
+split (but kept exactly as in the dix file). You can also set the
+environment variable LT_JOBS=true if you always want parallel
+minimisation even if lt-comp was called without this option.
 .It Fl h , Fl Fl help
 Prints a short help message.
 .It Cm lr

--- a/lttoolbox/lt_comp.cc
+++ b/lttoolbox/lt_comp.cc
@@ -50,7 +50,7 @@ void endProgram(char *name)
     cout << "  -r, --var-right:           set right language variant (bidix)" << endl;
     cout << "  -H, --hfst:                expect HFST symbols" << endl;
     cout << "  -S, --no-split:            don't attempt to split into word and punctuation transducers" << endl;
-    cout << "  -j, --jobs:                use one cpu core per section when minimising" << endl;
+    cout << "  -j, --jobs:                use one cpu core per section when minimising, new section after 50k entries" << endl;
 #else
     cout << "  -m:     keep morpheme boundaries" << endl;
     cout << "  -v:     set language variant" << endl;
@@ -59,7 +59,7 @@ void endProgram(char *name)
     cout << "  -r:     set right language variant (bidix)" << endl;
     cout << "  -H:     expect HFST symbols" << endl;
     cout << "  -S:     don't attempt to split into word and punctuation transducers" << endl;
-    cout << "  -j:     use one cpu core per section when minimising" << endl;
+    cout << "  -j:     use one cpu core per section when minimising, new section after 50k entries" << endl;
 #endif
     cout << "Modes:" << endl;
     cout << "  lr:     left-to-right compilation" << endl;
@@ -144,6 +144,7 @@ int main(int argc, char *argv[])
 
       case 'j':
         c.setJobs(true);
+        c.setMaxSectionEntries(50000);
         break;
 
       case 'V':
@@ -157,8 +158,12 @@ int main(int argc, char *argv[])
     }
   }
 
-  if(const char* jobs_env = std::getenv("LT_JOBS")) {
+  if(std::getenv("LT_JOBS")) {
     c.setJobs(true);
+    c.setMaxSectionEntries(50000);
+  }
+  if(const char* max_section_entries = std::getenv("LT_MAX_SECTION_ENTRIES")) {
+    c.setMaxSectionEntries(stol(max_section_entries));
   }
 
   string opc;


### PR DESCRIPTION
Number is overridable with env var `LT_MAX_SECTION_ENTRIES` 
(e.g. `export LT_MAX_SECTION_ENTRIES=5000`).

Fixes #134

Smaller sections also minimise faster, though after a certain point
the binary starts growing and total time increases again. Benching on
nob.dix where main section is about 260.000 entries, all columns are
with -j (4 cores) except the ones marked -j0:

```
| max entries | cpu secs | wall secs | cpu% | mem kb    | main sections | bin size | -j0 wall | -j0 mem   |
|-------------+----------+-----------+------+-----------+---------------+----------+----------+-----------|
|         500 |    21.62 |     10.87 |  203 |   699_300 |           496 | 4.2M     |    14.91 |   360_524 |
|        1000 |    20.47 |     09.58 |  218 |   658_172 |           248 | 3.7M     |    13.30 |   332_688 |
|        5000 |    23.02 |     09.35 |  250 |   652_964 |            50 | 2.9M     |    15.50 |   302_288 |
|       10000 |    25.10 |     09.98 |  254 |   665_204 |            25 | 2.7M     |    17.49 |   300_580 |
|       25000 |    28.85 |     12.96 |  225 |   699_964 |            10 | 2.5M     |    18.78 |   328_408 |
|       50000 |    29.64 |     13.72 |  219 |   678_776 |             5 | 2.4M     |    21.19 |   431_388 |
|      100000 |    27.95 |     16.99 |  167 |   896_884 |             3 | 2.4M     |    24.07 |   627_192 |
|      500000 |    26.74 |     27.86 |   97 | 1_105_992 |             1 | 2.4M     |    28.66 | 1_105_700 |
```
50k gives no increase in bin size while cutting time in half. 5k gives
best time while only a slight increase in bin size. Note also less
memory usage with more sections.

Running lt-proc on 10k corpus lines, the 5k entry bin takes 7.7s, 50k
takes 3.4s, while the original bin takes 2.9s. So we lose some in
processing speed, but lt-proc is far from being the bottleneck in
corpus processing.