### PR TITLE
Don't output duplicate strings from state finals, fixes #136

### DIFF
--- a/lttoolbox/state.cc
+++ b/lttoolbox/state.cc
@@ -529,8 +529,13 @@ State::filterFinals(map<Node *, double> const &finals,
   response = NFinals(response, max_analyses, max_weight_classes);
 
   result.clear();
+  set<UString> seen;
   for(vector<pair<UString, double>>::iterator it = response.begin(); it != response.end(); it++)
   {
+    if(seen.find(it->first) != seen.end()) {
+      continue;
+    }
+    seen.insert(it->first);
     result += '/';
     result += it->first;
     if(display_weights)

--- a/tests/data/sectiondupes.dix
+++ b/tests/data/sectiondupes.dix
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+  <sdefs>
+    <sdef n="n" 	c="Noun"/>
+  </sdefs>
+  <pardefs>
+  </pardefs>
+  <section id="main1" type="standard">
+    <e><p><l>a</l><r>a<s n="n"/></r></p></e>
+  </section>
+  <section id="main2" type="standard">
+    <e><p><l>a</l><r>a<s n="n"/></r></p></e>
+  </section>
+</dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -261,5 +261,13 @@ class AlphabeticMultibyteTestPost(ProcTest):
     expectedOutputs = ["𝜊"]
 
 
+class SectionDupes(ProcTest):
+    procdix = "data/sectiondupes.dix"
+    procdir = "rl"
+    inputs = ["^a<n>$"]
+    procflags = ['-z', '-g']
+    expectedOutputs = ["a"]
+
+
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *


### PR DESCRIPTION
Note: If there are duplicates with different weights, we print the one with the lowest (we still respect max_weight_classes) – is that ever bad?