### PR TITLE
Support compound analyses where left part has spaces

### DIFF
--- a/lttoolbox/buffer.h
+++ b/lttoolbox/buffer.h
@@ -175,6 +175,28 @@ public:
     }
 
   /**
+   * Look at the current element of the buffer without advancing.
+   * @return current element.
+   */
+  T & peek() const
+    {
+      if(currentpos != lastpos)
+      {
+        if(currentpos == size)
+        {
+          return buf[0];
+        }
+        else {
+          return buf[currentpos];
+        }
+      }
+      else
+      {
+        return last();
+      }
+    }
+
+  /**
    * Get the last element of the buffer.
    * @return last element.
    */
@@ -189,6 +211,7 @@ public:
         return buf[size-1];
       }
     }
+
 
   /**
    * Get the current buffer position.

--- a/lttoolbox/state.cc
+++ b/lttoolbox/state.cc
@@ -832,6 +832,25 @@ State::pruneStatesWithForbiddenSymbol(int forbiddenSymbol)
 }
 
 
+bool
+State::hasSymbol(int requiredSymbol)
+{
+  for(size_t i = 0; i<state.size(); i++)
+  {
+    // loop through sequence – we can't just check that the last tag is cp-L, there may be other tags after it:
+    vector<pair<int, double>>* seq = state.at(i).sequence;
+    if(seq != NULL) for (unsigned int j=0; j<seq->size(); j++)
+    {
+      int symbol=(seq->at(j)).first;
+      if(symbol == requiredSymbol)
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 
 bool
 State::lastPartHasRequiredSymbol(const vector<pair<int, double>> &seq, int requiredSymbol, int separationSymbol)

--- a/lttoolbox/state.h
+++ b/lttoolbox/state.h
@@ -222,6 +222,12 @@ public:
   void pruneStatesWithForbiddenSymbol(int forbiddenSymbol);
 
   /**
+    * Whether any of the analyses contains a certain symbol
+    * @param requiredSymbol the symbol we're looking for
+    */
+  bool hasSymbol(int requiredSymbol);
+
+  /**
    * Returns the lexical form in a sorted by weights manner
    * and restricts to N analyses or N weight classes if those options are provided.
    * @param the original lexical form map

--- a/tests/data/spcmp.dix
+++ b/tests/data/spcmp.dix
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+	<alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+	<sdefs>
+	  <sdef n="n"/>
+	  <sdef n="pr"/>
+	  <sdef n="det"/>
+	  <sdef n="guio"/>
+	  <sdef n="compound-only-L"/>
+	  <sdef n="compound-R"/>
+        </sdefs>
+<pardefs>
+
+</pardefs>
+
+<section id="cmp" type="standard">
+  <!-- "a 1-b" should (only) be possible as a dynamic compound: -->
+  <e><p><l>a<b/>1-</l> <r>a<b/>1<s n="n"/><s n="compound-only-L"/></r></p></e>
+  <e><p><l>b</l>       <r>b<s n="n"/><s n="compound-R"/></r></p></e>
+  <e><p><l>c</l>       <r>c<s n="n"/><s n="compound-R"/></r></p></e>
+
+  <!-- "a 1-c" is a lexicalised compound: -->
+  <e><p><l>a<b/>1-c</l><r>a<b/>1-c<s n="n"/></r></p></e>
+  <e><p><l>a<b/>1-d</l><r>a<b/>1-d<s n="n"/></r></p></e>
+
+  <e><p><l>w</l>  <r>w<s n="n"/><s n="compound-only-L"/></r></p></e>
+  <e><p><l>wy</l> <r>wy<s n="n"/></r></p></e>
+  <e><p><l>wy<b/>x</l> <r>wy<b/>x<s n="n"/></r></p></e>
+
+  <e><p><l>a</l>       <r>a<s n="pr"/></r></p></e>
+</section>
+<section id="final" type="inconditional">
+  <e><p><l>1</l>       <r>1<s n="det"/></r></p></e>
+  <e><p><l>-</l>       <r>-<s n="guio"/></r></p></e>
+</section>
+
+</dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -269,5 +269,29 @@ class SectionDupes(ProcTest):
     expectedOutputs = ["a"]
 
 
+class SpaceCompound(ProcTest):
+    procdix = "data/spcmp.dix"
+    inputs = ["a 1-b",
+              "a 1-b_",
+              "a 1-b ",
+              "a 1-b a",
+              "a 1-c",
+              "a 1-c_",
+              "a 1-c ",
+              "wy a",
+              ]
+    procflags = ['-z', '-w', '-e']
+    expectedOutputs = [
+        "^a 1-b/a 1<n>+b<n>$",
+        "^a 1-b/a 1<n>+b<n>$_",
+        "^a 1-b/a 1<n>+b<n>$ ",
+        "^a 1-b/a 1<n>+b<n>$ ^a/a<pr>$",
+        "^a 1-c/a 1-c<n>$",
+        "^a 1-c/a 1-c<n>$_",
+        "^a 1-c/a 1-c<n>$ ",
+        "^wy/wy<n>$ ^a/a<pr>$",
+        ]
+
+
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *


### PR DESCRIPTION
So if "kake" and "formel 1-<compound-only-L>" are in dix, we can
analyse "formel 1-kake" as a compound. One left-part has to have all
the spaces (so "kakeformel 1" isn't supported, nor is
"formel 1-formel 1").

Only takes effect when run with -e option.

This closes #138

-----

It makes analysis slightly slower when compounding is in effect (and your FST has multiwords with compounding), but lt-proc is far from being the bottleneck. For nob-dan, it's negligible: 13.8s vs 13.6s on 50k lines. For nob-nno, 19.9s vs 17.9s on 50k lines. 

For Norwegian, these types of compounds tend to always have a dash, but it was simpler to implement without that requirement, so .dix writers get to (have to) decide if they want space words to be able to cp-L without dash.

Caveat: If the dix already has space words which allow cp-L but shouldn't, they'll now start compounding. This should be fixed in dix anyway, but it'll alter translations. I think I maintain most of the .dix that use compounding though :)