### PR TITLE
liblttoolbox3 must be linked with libicu

### DIFF
--- a/lttoolbox/Makefile.am
+++ b/lttoolbox/Makefile.am
@@ -20,6 +20,7 @@ instdir = lttoolbox
 lib_LTLIBRARIES= liblttoolbox3.la
 liblttoolbox3_la_SOURCES= $(h_sources) $(cc_sources)
 liblttoolbox3_la_LDFLAGS= -version-info $(SOVERSION) -release $(VERSION_API)
+liblttoolbox3_la_LIBADD= $(ICU_LIBS)
 
 lttoolboxdir = $(prefix)/share/lttoolbox
 lttoolboxinclude = $(prefix)/include


### PR DESCRIPTION
Warning during the Debian package build:

https://buildd.debian.org/status/fetch.php?pkg=lttoolbox&arch=amd64&ver=3.6.1-2%2Bb2&stamp=1650723091&raw=0
```
   dh_shlibdeps -a
dpkg-shlibdeps: warning: symbol u_strCaseCompare_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol u_tolower_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol u_isdigit_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol u_errorName_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol u_sscanf_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol u_strHasMoreChar32Than_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol u_fclose_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol uloc_setDefault_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol _ZN6icu_7122UCharCharacterIterator7hasNextEv used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: symbol u_isspace_71 used by debian/liblttoolbox3-3.6-1/usr/lib/x86_64-linux-gnu/liblttoolbox3-3.6.so.1.0.0 found in none of the libraries
dpkg-shlibdeps: warning: 20 other similar warnings have been skipped (use -v to see them all)
```


It works when all users also happen to link with (the right version of) libicu, if they don't linking or running code using liblttoolbox3 fails like:

https://buildd.debian.org/status/fetch.php?pkg=apertium&arch=ppc64&ver=3.8.1-2%2Bb2&stamp=1650794468&raw=0
```
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_isalnum_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_strHasMoreChar32Than_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_isspace_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_feof_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_finit_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_toupper_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `icu_67::UCharCharacterIterator::UCharCharacterIterator(icu_67::ConstChar16Ptr, int)'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_errorName_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_fopen_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_sprintf_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `icu_67::UCharCharacterIterator::hasNext()'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_fflush_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `icu_67::UCharCharacterIterator::next32PostInc()'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_fgetc_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_fputc_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_snprintf_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_isupper_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_strToUpper_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_fprintf_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_islower_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_sscanf_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_strToLower_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `uloc_setDefault_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `icu_67::UCharCharacterIterator::~UCharCharacterIterator()'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_tolower_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_fclose_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_isdigit_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_ispunct_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_strToTitle_67'
/usr/bin/ld: /usr/lib/gcc/powerpc64-linux-gnu/11/../../../powerpc64-linux-gnu/liblttoolbox3.so: undefined reference to `u_strCaseCompare_67'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:1143: apertium-cleanstream] Error 1
```