### PR TITLE
Merge Postgen, Intergen, and Transliteration

### DIFF
--- a/lttoolbox/alphabet.cc
+++ b/lttoolbox/alphabet.cc
@@ -300,3 +300,29 @@ Alphabet::createLoopbackSymbols(std::set<int32_t> &symbols, Alphabet &basis, Sid
     }
   }
 }
+
+std::vector<int32_t>
+Alphabet::tokenize(const UString& str) const
+{
+  std::vector<int32_t> ret;
+  size_t end = str.size();
+  size_t i = 0;
+  UChar32 c;
+  while (i < end) {
+    U16_NEXT(str.c_str(), i, end, c);
+    if (c == '\\') {
+    } else if (c == '<') {
+      size_t j = i;
+      while (c != '>' && j < end) {
+        U16_NEXT(str.c_str(), j, end, c);
+      }
+      if (c == '>') {
+        ret.push_back(operator()(str.substr(i-1, j-i)));
+        i = j;
+      }
+    } else {
+      ret.push_back(static_cast<int32_t>(c));
+    }
+  }
+  return ret;
+}

--- a/lttoolbox/alphabet.h
+++ b/lttoolbox/alphabet.h
@@ -196,6 +196,8 @@ public:
    * @param nonTagsToo by default only tags are included, but if this is true we include all symbols
    */
   void createLoopbackSymbols(std::set<int32_t> &symbols, Alphabet &basis, Side s = right, bool nonTagsToo = false);
+
+  std::vector<int32_t> tokenize(const UString& str) const;
 };
 
 #endif

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -19,6 +19,7 @@
 #include <lttoolbox/exception.h>
 #include <lttoolbox/xml_parse_util.h>
 #include <lttoolbox/file_utils.h>
+#include <lttoolbox/string_utils.h>
 
 #include <iostream>
 #include <cerrno>
@@ -32,8 +33,6 @@ UString const FSTProcessor::XML_RESTORE_CHAR_ELEM   = "restore-char"_u;
 UString const FSTProcessor::XML_RESTORE_CHARS_ELEM  = "restore-chars"_u;
 UString const FSTProcessor::XML_VALUE_ATTR          = "value"_u;
 UString const FSTProcessor::XML_CHAR_ELEM           = "char"_u;
-UString const FSTProcessor::WBLANK_START            = "[["_u;
-UString const FSTProcessor::WBLANK_END              = "]]"_u;
 UString const FSTProcessor::WBLANK_FINAL            = "[[/]]"_u;
 
 
@@ -173,67 +172,6 @@ FSTProcessor::procNodeRCX()
     std::cerr << "): Invalid node '<" << name << ">'." << std::endl;
     exit(EXIT_FAILURE);
   }
-}
-
-bool
-FSTProcessor::wblankPostGen(InputFile& input, UFILE *output)
-{
-  UString result = WBLANK_START;
-  UChar32 c = 0;
-  bool in_content = false;
-
-  while(!input.eof())
-  {
-    c = input.get();
-    if(in_content && c == '~')
-    {
-      if(result[result.size()-1] == ']') {
-        // We just saw the end of a wblank, may want to merge
-        wblankqueue.push(result);
-      }
-      else {
-        // wake-up-mark happened some characters into the wblanked word
-        write(result, output);
-      }
-      return true;
-    }
-    else
-    {
-      result += c;
-    }
-
-    if(c == '\\')
-    {
-      if (input.eof()) streamError();
-      result += input.get();
-    }
-    else if(c == ']')
-    {
-      c = input.get();
-      result += c;
-
-      if(c == ']')
-      {
-        int resultlen = result.size();
-        if(result[resultlen-5] == '[' && result[resultlen-4] == '[' && result[resultlen-3] == '/') //ending blank [[/]]
-        {
-          write(result, output);
-          break;
-        }
-        else
-        {
-          in_content = true; // Assumption: No nested wblanks, always balanced
-        }
-      }
-    }
-  }
-
-  if(c != ']')
-  {
-    streamError();
-  }
-
-  return false;
 }
 
 int
@@ -385,68 +323,93 @@ FSTProcessor::readTMAnalysis(InputFile& input)
   return val;
 }
 
-int32_t
-FSTProcessor::readPostgeneration(InputFile& input, UFILE *output)
+bool
+FSTProcessor::readTransliterationBlank(InputFile& input)
 {
-  if(!input_buffer.isEmpty())
-  {
-    return input_buffer.next();
+  UString blank;
+  while (!input.eof()) {
+    UChar32 c = input.get();
+    if (u_isspace(c)) {
+      blank += c;
+    } else if (c == '[') {
+      if (input.peek() == '[') {
+        break;
+      }
+      blank += input.readBlock('[', ']');
+    } else {
+      input.unget(c);
+      break;
+    }
+  }
+  if (!blank.empty()) {
+    blankqueue.push(blank);
+  }
+  return !blank.empty();
+}
+
+bool
+FSTProcessor::readTransliterationWord(InputFile& input)
+{
+  if (input.eof() || input.peek() == '\0') {
+    return false;
   }
 
-  UChar32 val = input.get();
-  int32_t altval = 0;
-  is_wblank = false;
-  if(input.eof())
-  {
-    return 0;
+  if (!readTransliterationBlank(input)) {
+    blankqueue.push(""_u);
   }
 
-  switch(val)
-  {
-    case '<':
-      altval = alphabet(input.readBlock('<', '>'));
-      input_buffer.add(altval);
-      return altval;
-
-    case '[':
-      val = input.get();
-
-      if(val == '[')
-      {
-        if(collect_wblanks)
-        {
-          wblankqueue.push(input.finishWBlank());
-          is_wblank = true;
-          return static_cast<int32_t>(' ');
-        }
-        else if(wblankPostGen(input, output))
-        {
-          return static_cast<int32_t>('~');
-        }
-        else
-        {
-          is_wblank = true;
-          return static_cast<int32_t>(' ');
+  UString wblank;
+  std::vector<int32_t> word;
+  if (input.peek() == '[') {
+    input.get();
+    wblank = input.finishWBlank();
+    while (!input.eof()) {
+      if (readTransliterationBlank(input)) {
+        word.push_back(static_cast<int32_t>(' '));
+        if (input.peek() == '[') break;
+      } else {
+        UChar32 c = input.get();
+        if (c == '[') {
+          input.unget(c);
+          break;
+        } else if (c == '\\') {
+          word.push_back(static_cast<int32_t>(input.get()));
+        } else if (c == '<') {
+          word.push_back(alphabet(input.readBlock('<', '>')));
+        } else if (c == '\0') {
+          input.unget(c);
+          break;
+        } else {
+          word.push_back(static_cast<int32_t>(c));
         }
       }
-      else
-      {
-        input.unget(val);
-        blankqueue.push(input.readBlock('[', ']'));
-
-        input_buffer.add(static_cast<int32_t>(' '));
-        return static_cast<int32_t>(' ');
+    }
+    if (input.peek() == '[') {
+      input.get();
+      input.finishWBlank();
+    }
+  } else {
+    while (!input.eof()) {
+      UChar32 c = input.get();
+      if (u_isspace(c) || c == '[' || c == '\0') {
+        input.unget(c);
+        break;
+      } else if (c == '\\') {
+        word.push_back(static_cast<int32_t>(input.get()));
+      } else if (c == '<') {
+        word.push_back(alphabet(input.readBlock('<', '>')));
+      } else {
+        word.push_back(static_cast<int32_t>(c));
       }
-
-    case '\\':
-      val = input.get();
-      input_buffer.add(static_cast<int32_t>(val));
-      return val;
-
-    default:
-      input_buffer.add(val);
-      return val;
+    }
   }
+  if (word.empty()) {
+    return false;
+  }
+  wblankqueue.push_back(wblank);
+  transliteration_queue.push_back(word);
+
+  return true;
 }
 
 void
@@ -682,65 +645,6 @@ FSTProcessor::flushBlanks(UFILE *output)
 }
 
 void
-FSTProcessor::flushWblanks(UFILE *output)
-{
-  while(wblankqueue.size() > 0)
-  {
-    write(wblankqueue.front(), output);
-    wblankqueue.pop();
-  }
-}
-
-UString
-FSTProcessor::combineWblanks()
-{
-  UString final_wblank;
-  UString last_wblank;
-  bool seen_wblank = false;
-
-  while(wblankqueue.size() > 0)
-  {
-    if(wblankqueue.front().compare(WBLANK_FINAL) == 0)
-    {
-      if(seen_wblank) {
-        if(final_wblank.empty())
-        {
-          final_wblank += WBLANK_START;
-        }
-        else if(final_wblank.size() > 2)
-        {
-          final_wblank += "; "_u;
-        }
-
-        final_wblank += last_wblank.substr(2,last_wblank.size()-4); //add wblank without brackets [[..]]
-      }
-      else {
-        need_end_wblank = true;
-      }
-      last_wblank.clear();
-    }
-    else
-    {
-      seen_wblank = true;
-      last_wblank = wblankqueue.front();
-    }
-    wblankqueue.pop();
-  }
-
-  if(!last_wblank.empty())
-  {
-    wblankqueue.push(last_wblank);
-  }
-
-  if(!final_wblank.empty())
-  {
-    final_wblank += WBLANK_END;
-    need_end_wblank = true;
-  }
-  return final_wblank;
-}
-
-void
 FSTProcessor::calcInitial()
 {
   for(auto& it : transducers) {
@@ -750,39 +654,26 @@ FSTProcessor::calcInitial()
   initial_state.init(&root);
 }
 
-bool
-FSTProcessor::endsWith(UString const &str, UString const &suffix)
-{
-  if(str.size() < suffix.size())
-  {
-    return false;
-  }
-  else
-  {
-    return str.substr(str.size()-suffix.size()) == suffix;
-  }
-}
-
 void
 FSTProcessor::classifyFinals()
 {
   for(auto& it : transducers) {
-    if(endsWith(it.first, "@inconditional"_u))
+    if(StringUtils::endswith(it.first, "@inconditional"_u))
     {
       inconditional.insert(it.second.getFinals().begin(),
                            it.second.getFinals().end());
     }
-    else if(endsWith(it.first, "@standard"_u))
+    else if(StringUtils::endswith(it.first, "@standard"_u))
     {
       standard.insert(it.second.getFinals().begin(),
                       it.second.getFinals().end());
     }
-    else if(endsWith(it.first, "@postblank"_u))
+    else if(StringUtils::endswith(it.first, "@postblank"_u))
     {
       postblank.insert(it.second.getFinals().begin(),
                        it.second.getFinals().end());
     }
-    else if(endsWith(it.first, "@preblank"_u))
+    else if(StringUtils::endswith(it.first, "@preblank"_u))
     {
       preblank.insert(it.second.getFinals().begin(),
                       it.second.getFinals().end());
@@ -1003,7 +894,7 @@ FSTProcessor::initGeneration()
 }
 
 void
-FSTProcessor::initPostgeneration()
+FSTProcessor::initTransliteration()
 {
   initGeneration();
 }
@@ -1409,42 +1300,6 @@ FSTProcessor::generation_wrapper_null_flush(InputFile& input, UFILE *output,
 }
 
 void
-FSTProcessor::postgeneration_wrapper_null_flush(InputFile& input, UFILE *output)
-{
-  setNullFlush(false);
-  while(!input.eof())
-  {
-    postgeneration(input, output);
-    u_fputc('\0', output);
-    u_fflush(output);
-  }
-}
-
-void
-FSTProcessor::intergeneration_wrapper_null_flush(InputFile& input, UFILE *output)
-{
-  setNullFlush(false);
-  while (!input.eof())
-  {
-    intergeneration(input, output);
-    u_fputc('\0', output);
-    u_fflush(output);
-  }
-}
-
-void
-FSTProcessor::transliteration_wrapper_null_flush(InputFile& input, UFILE *output)
-{
-  setNullFlush(false);
-  while(!input.eof())
-  {
-    transliteration(input, output);
-    u_fputc('\0', output);
-    u_fflush(output);
-  }
-}
-
-void
 FSTProcessor::tm_analysis(InputFile& input, UFILE *output)
 {
   State current_state = initial_state;
@@ -1764,422 +1619,207 @@ FSTProcessor::generation(InputFile& input, UFILE *output, GenerationMode mode)
 void
 FSTProcessor::postgeneration(InputFile& input, UFILE *output)
 {
-  if(getNullFlush())
-  {
-    postgeneration_wrapper_null_flush(input, output);
-  }
-
-  bool skip_mode = true;
-  collect_wblanks = false;
-  need_end_wblank = false;
-  State current_state = initial_state;
-  UString lf;
-  UString sf;
-  int last = 0;
-  std::set<UChar32> empty_escaped_chars;
-
-  while(UChar32 val = readPostgeneration(input, output))
-  {
-    if(val == '~')
-    {
-      skip_mode = false;
-      collect_wblanks = true;
-    }
-
-    if(is_wblank && skip_mode)
-    {
-      //do nothing
-    }
-    else if(skip_mode)
-    {
-      if(u_isspace(val))
-      {
-        if(need_end_wblank)
-        {
-          write(WBLANK_FINAL, output);
-          need_end_wblank = false;
-        }
-
-        printSpace(val, output);
-      }
-      else
-      {
-        if(!need_end_wblank)
-        {
-          flushWblanks(output);
-        }
-
-        if(isEscaped(val))
-        {
-          u_fputc('\\', output);
-        }
-        u_fputc(val, output);
-
-        if(need_end_wblank)
-        {
-          write(WBLANK_FINAL, output);
-          need_end_wblank = false;
-        }
-      }
-    }
-    else
-    {
-      if(is_wblank)
-      {
-        continue;
-      }
-
-      // test for final states
-      if(current_state.isFinal(all_finals))
-      {
-        bool firstupper = u_isupper(sf[1]);
-        bool uppercase = sf.size() > 1 && firstupper && u_isupper(sf[2]);
-        lf = current_state.filterFinals(all_finals, alphabet,
-                                        empty_escaped_chars,
-                                        displayWeightsMode, maxAnalyses, maxWeightClasses,
-                                        uppercase, firstupper, 0);
-
-        // case of the beggining of the next word
-
-        UString mybuf;
-        for(size_t i = sf.size(); i > 0; --i)
-        {
-          if(!isalpha(sf[i-1]))
-          {
-            break;
-          }
-          else
-          {
-            mybuf = sf[i-1] + mybuf;
-          }
-        }
-
-        if(mybuf.size() > 0)
-        {
-          bool myfirstupper = u_isupper(mybuf[0]);
-          bool myuppercase = mybuf.size() > 1 && u_isupper(mybuf[1]);
-
-          for(size_t i = lf.size(); i > 0; --i)
-          {
-            if(!isalpha(lf[i-1]))
-            {
-              if(myfirstupper && i != lf.size())
-              {
-                lf[i] = u_toupper(lf[i]);
-              }
-              else
-              {
-                lf[i] = u_tolower(lf[i]);
-              }
-              break;
-            }
-            else
-            {
-              if(myuppercase)
-              {
-                lf[i-1] = u_toupper(lf[i-1]);
-              }
-              else
-              {
-                lf[i-1] = u_tolower(lf[i-1]);
-              }
-            }
-          }
-        }
-
-        last = input_buffer.getPos();
-      }
-
-      current_state.step_case(val, caseSensitive);
-
-      if(current_state.size() != 0)
-      {
-        alphabet.getSymbol(sf, val);
-      }
-      else
-      {
-        UString final_wblank = combineWblanks();
-        write(final_wblank, output);
-
-        if(lf.empty())
-        {
-          unsigned int mark = sf.size();
-          unsigned int space_index = sf.size();
-
-          for(unsigned int i = 1, limit = sf.size(); i < limit; i++)
-          {
-            if(sf[i] == '~')
-            {
-              mark = i;
-              break;
-            }
-            else if(sf[i] == ' ')
-            {
-              space_index = i;
-            }
-          }
-
-          if(space_index != sf.size())
-          {
-            write(sf.substr(1, space_index-1), output);
-
-            if(need_end_wblank)
-            {
-              write(WBLANK_FINAL, output);
-              need_end_wblank = false;
-              u_fputc(sf[space_index], output);
-              flushWblanks(output);
-            }
-            else
-            {
-              u_fputc(sf[space_index], output);
-            }
-
-            write(sf.substr(space_index+1, mark-space_index-1), output);
-          }
-          else
-          {
-            flushWblanks(output);
-            write(sf.substr(1, mark-1), output);
-          }
-
-          if(mark == sf.size())
-          {
-            input_buffer.back(1);
-          }
-          else
-          {
-            input_buffer.back(sf.size()-mark);
-          }
-        }
-        else
-        {
-          write(lf.substr(1,lf.size()-3), output);
-          input_buffer.setPos(last);
-          input_buffer.back(2);
-          val = lf[lf.size()-2];
-          if(u_isspace(val))
-          {
-            printSpace(val, output);
-          }
-          else
-          {
-            if(isEscaped(val))
-            {
-              u_fputc('\\', output);
-            }
-            u_fputc(val, output);
-          }
-        }
-
-        current_state = initial_state;
-        lf.clear();
-        sf.clear();
-        skip_mode = true;
-        collect_wblanks = false;
-      }
-    }
-  }
-
-  // print remaining blanks
-  flushBlanks(output);
+  transliteration_drop_tilde = true;
+  transliteration(input, output);
 }
 
 void
 FSTProcessor::intergeneration(InputFile& input, UFILE *output)
 {
-  if (getNullFlush())
-  {
-    intergeneration_wrapper_null_flush(input, output);
-  }
-
-  bool skip_mode = true;
-  State current_state = initial_state;
-  UString target;
-  UString source;
-  int last = 0;
-  std::set<UChar32> empty_escaped_chars;
-
-  while (true)
-  {
-    UChar32 val = readPostgeneration(input, output);
-
-    if (val == '~')
-    {
-      skip_mode = false;
-    }
-
-    if (skip_mode)
-    {
-      if (u_isspace(val))
-      {
-        printSpace(val, output);
-      }
-      else
-      {
-        if(val != '\0')
-        {
-          if (isEscaped(val))
-          {
-            u_fputc('\\', output);
-          }
-          u_fputc(val, output);
-        }
-      }
-    }
-    else
-    {
-      // test for final states
-      if (current_state.isFinal(all_finals))
-      {
-        bool firstupper = u_isupper(source[1]);
-        bool uppercase = source.size() > 1 && firstupper && u_isupper(source[2]);
-        target = current_state.filterFinals(all_finals, alphabet,
-                                        empty_escaped_chars,
-                                        displayWeightsMode, maxAnalyses, maxWeightClasses,
-                                        uppercase, firstupper, 0);
-
-        last = input_buffer.getPos();
-      }
-
-      if (val != '\0')
-      {
-        current_state.step_case(val, caseSensitive);
-      }
-
-      if (val != '\0' && current_state.size() != 0)
-      {
-        alphabet.getSymbol(source, val);
-      }
-      else
-      {
-        if (target.empty()) // no match
-        {
-          if (val == '\0')
-          {
-            // flush source
-            write(source, output);
-          }
-          else
-          {
-            u_fputc(source[0], output);
-
-            unsigned int mark, limit;
-            for (mark = 1, limit = source.size(); mark < limit && source[mark] != '~' ; mark++)
-            {
-              u_fputc(source[mark], output);
-            }
-
-            if (mark != source.size())
-            {
-              int back = source.size() - mark;
-              input_buffer.back(back);
-            }
-
-            if (val == '~')
-            {
-              input_buffer.back(1);
-            } else {
-               u_fputc(val, output);
-            }
-          }
-        }
-        else
-        {
-          for(unsigned int i=1; i<target.size(); i++) {
-            UChar c = target[i];
-
-            if (u_isspace(c))
-            {
-              printSpace(c, output);
-            }
-            else
-            {
-              if (isEscaped(c))
-              {
-                u_fputc('\\', output);
-              }
-              u_fputc(c, output);
-            }
-          }
-
-          if (val != '\0')
-          {
-            input_buffer.setPos(last);
-            input_buffer.back(1);
-          }
-        }
-
-        current_state = initial_state;
-        target.clear();
-        source.clear();
-        skip_mode = true;
-      }
-    }
-
-    if (val == '\0')
-    {
-      break;
-    }
-  }
-
-  // print remaining blanks
-  flushBlanks(output);
+  transliteration_drop_tilde = false;
+  transliteration(input, output);
 }
 
 void
 FSTProcessor::transliteration(InputFile& input, UFILE *output)
 {
-  if(getNullFlush())
-  {
-    transliteration_wrapper_null_flush(input, output);
-  }
+  size_t start_pos = 0;
+  size_t cur_word = 0;
+  size_t cur_pos = 0;
+  size_t match_pos = 0;
+  current_state = initial_state;
+  UString last_match;
+  int space_diff = 0;
 
-  State current_state = initial_state;
-  UString lf;
-  UString sf;
-  UString last_lf;
-  int rewind_point = 0;
-  int last_match = 0;
-  UChar32 firstchar = 0;
+  bool firstupper = false;
+  bool uppercase = false;
+  bool have_first = false;
+  bool have_second = false;
 
-  while(UChar32 val = readPostgeneration(input, output)) {
-    if (sf.empty()) {
-      firstchar = val;
-      rewind_point = input_buffer.getPos();
-    } else {
-      lf = filterFinals(current_state, sf);
-      if (!lf.empty()) {
-        last_match = input_buffer.getPos();
-        last_lf.swap(lf);
+  while (true) {
+    if (transliteration_queue.empty()) {
+      if (!blankqueue.empty()) {
+        flushBlanks(output);
+      }
+      if (!readTransliterationWord(input)) {
+        flushBlanks(output);
+        if (input.eof()) {
+          break;
+        } else {
+          u_fputc(input.get(), output);
+          u_fflush(output);
+          continue;
+        }
       }
     }
-    current_state.step(val);
-    if (current_state.size() != 0) {
-      alphabet.getSymbol(sf, val);
-    } else {
-      if (last_lf.empty()) {
-        input_buffer.setPos(rewind_point);
-        if (u_isspace(firstchar)) {
-          printSpace(firstchar, output);
-        } else {
-          if (isEscaped(firstchar)) {
-            u_fputc('\\', output);
+
+    if (current_state.isFinal(all_finals)) {
+      last_match = current_state.filterFinals(all_finals, alphabet,
+                                              escaped_chars, displayWeightsMode,
+                                              maxAnalyses, maxWeightClasses,
+                                              uppercase, firstupper);
+      while (cur_word > 0) {
+        if (cur_word == 1) {
+          if (cur_pos == 0 && last_match[last_match.size()-1] == ' ') {
+            match_pos = transliteration_queue.front().size();
+            last_match = last_match.substr(0, last_match.size()-1);
+            break;
+          } else {
+            cur_pos += transliteration_queue.front().size() + 1;
           }
-          u_fputc(firstchar, output);
         }
-      } else {
-        write(last_lf.substr(1), output);
-        last_lf.clear();
-        input_buffer.setPos(last_match);
-        input_buffer.back(1);
+        std::vector<int32_t> word = transliteration_queue.front();
+        transliteration_queue.pop_front();
+        word.push_back(static_cast<int32_t>(' '));
+        word.insert(word.end(), transliteration_queue.front().begin(),
+                    transliteration_queue.front().end());
+        transliteration_queue.pop_front();
+        transliteration_queue.push_front(word);
+        UString wblank = wblankqueue.front();
+        wblankqueue.pop_front();
+        wblank = StringUtils::merge_wblanks(wblank, wblankqueue.front());
+        wblankqueue.pop_front();
+        wblankqueue.push_front(wblank);
+        cur_word--;
       }
-      sf.clear();
+      if (cur_word == 0) {
+        match_pos = cur_pos;
+      }
+    }
+
+    int32_t sym = 0;
+    bool is_end = false;
+    if (cur_pos < transliteration_queue[cur_word].size()) {
+      sym = transliteration_queue[cur_word][cur_pos];
+      cur_pos++;
+    } else {
+      if (cur_word + 1 == transliteration_queue.size() &&
+          !readTransliterationWord(input)) {
+        is_end = true;
+      } else {
+        sym = static_cast<int32_t>(' ');
+        cur_word++;
+        cur_pos = 0;
+      }
+    }
+
+    if (isAlphabetic(sym)) {
+      if (!have_first) {
+        have_first = true;
+        if (u_isupper(sym)) {
+          firstupper = true;
+        } else {
+          firstupper = false;
+          have_second = true;
+        }
+      } else if (!have_second) {
+        have_second = true;
+        uppercase = u_isupper(sym);
+      }
+    }
+
+    current_state.step_case(sym, caseSensitive);
+
+    if (current_state.size() == 0 || is_end) {
+      if (last_match.empty()) {
+        start_pos++;
+      } else {
+        std::vector<int32_t> match = alphabet.tokenize(last_match.substr(1));
+        last_match.clear();
+        std::vector<int32_t> word = transliteration_queue.front();
+        transliteration_queue.pop_front();
+        size_t i = 0;
+        for (; i < match.size() && i < match_pos - start_pos; i++) {
+          if (match[match.size()-i-1] != word[word.size()-i-1]) {
+            break;
+          }
+        }
+        std::vector<int32_t> new_word;
+        new_word.insert(new_word.end(), word.begin(), word.begin()+start_pos);
+        new_word.insert(new_word.end(), match.begin(), match.end());
+        new_word.insert(new_word.end(), word.begin()+match_pos, word.end());
+        transliteration_queue.push_front(new_word);
+        int sf_spaces = 0;
+        int lf_spaces = 0;
+        for (auto c : word) {
+          if (c == static_cast<int32_t>(' ')) sf_spaces++;
+        }
+        for (auto c : new_word) {
+          if (c == static_cast<int32_t>(' ')) lf_spaces++;
+        }
+        space_diff += (lf_spaces - sf_spaces);
+        size_t last_start = start_pos;
+        start_pos = match_pos - i;
+        if (start_pos == last_start) start_pos++;
+        cur_pos = start_pos;
+        cur_word = 0;
+      }
+      if (start_pos >= transliteration_queue.front().size()) {
+        write(blankqueue.front(), output);
+        blankqueue.pop();
+        bool has_wblank = !wblankqueue.front().empty();
+        write(wblankqueue.front(), output);
+        wblankqueue.pop_front();
+        auto word = transliteration_queue.front();
+        transliteration_queue.pop_front();
+        int space_count = 0;
+        for (auto c : word) {
+          if (c == static_cast<int32_t>(' ')) space_count++;
+        }
+        int space_out = 0;
+        UString out;
+        for (auto c : word) {
+          if (c == ' ') {
+            if (space_out + space_diff >= space_count) {
+              out += ' ';
+            } else {
+              out += blankqueue.front();
+              blankqueue.pop();
+            }
+            space_out++;
+          } else if (transliteration_drop_tilde &&
+                     c == static_cast<int32_t>('~')) {
+          } else {
+            if (c > 0 && isEscaped(c)) {
+              out += '\\';
+            }
+            alphabet.getSymbol(out, c);
+          }
+        }
+        write(out, output);
+        if (has_wblank) {
+          write(WBLANK_FINAL, output);
+        }
+        while (space_diff < 0) {
+          if (blankqueue.front() != " "_u) {
+            write(blankqueue.front(), output);
+          }
+          blankqueue.pop();
+          space_diff++;
+        }
+        space_diff = 0;
+        start_pos = 0;
+      }
+      match_pos = 0;
+      cur_pos = start_pos;
+      cur_word = 0;
+      uppercase = false;
+      firstupper = false;
+      have_first = false;
+      have_second = false;
       current_state = initial_state;
     }
   }
-  // print remaining blanks
-  flushBlanks(output);
 }
 
 UString

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -28,6 +28,7 @@
 #include <lttoolbox/input_file.h>
 #include <libxml/xmlreader.h>
 
+#include <deque>
 #include <map>
 #include <queue>
 #include <set>
@@ -106,7 +107,9 @@ private:
   /**
    * Queue of wordbound blanks, used in reading methods
    */
-  std::queue<UString> wblankqueue;
+  std::deque<UString> wblankqueue;
+
+  std::deque<std::vector<int32_t>> transliteration_queue;
 
   /**
    * Set of characters being considered alphabetics
@@ -232,20 +235,7 @@ private:
    */
   int maxAnalyses = INT_MAX;
 
-  /**
-   * True if a wblank block ([[..]]xyz[[/]]) was just read
-   */
-  bool is_wblank;
-
-  /**
-   * True if skip_mode is false and need to collect wblanks
-   */
-  bool collect_wblanks;
-
-  /**
-   * True if a wblank has been processed for postgen and we need an ending wblank
-   */
-  bool need_end_wblank;
+  bool transliteration_drop_tilde = false;
 
   /**
    * Output no more than 'N' best weight classes
@@ -256,14 +246,6 @@ private:
    * Prints an error of input stream and exits
    */
   void streamError();
-
-  /**
-   * Reads a wordbound blank (opening blank to closing blank) from the stream input -> [[...]]xyz[[/]]
-   * @param input the stream being read
-   * @param output the stream to write on
-   * @return true if the word enclosed by the wordbound blank has a ~ for postgeneration activation
-   */
-  bool wblankPostGen(InputFile& input, UFILE *output);
 
   /**
    * Returns true if the character code is identified as alphabetic
@@ -294,13 +276,8 @@ private:
    */
   int readDecomposition(InputFile& input, UFILE *output);
 
-  /**
-   * Read text from stream (postgeneration version)
-   * @param input the stream to read
-   * @param output the stream to write on
-   * @return the next symbol in the stream
-   */
-  int readPostgeneration(InputFile& input, UFILE *output);
+  bool readTransliterationBlank(InputFile& input);
+  bool readTransliterationWord(InputFile& input);
 
   /**
    * Read text from stream (generation version)
@@ -330,26 +307,6 @@ private:
    * @param output stream to write blanks
    */
   void flushBlanks(UFILE *output);
-
-  /**
-   * Flush all the wordbound blanks remaining in the current process
-   * @param output stream to write blanks
-   */
-  void flushWblanks(UFILE *output);
-
-  /**
-   * Combine wordbound blanks in the queue and return them.
-   *
-   * May pop from 'wblankqueue' and set 'need_end_wblank' to true.
-   *
-   * If 'wblankqueue' (see which) is empty, we get an empty string,
-   * otherwise we return a semicolon-separated combination of opening
-   * wblanks in the queue. If there is only a closing wblank, we just
-   * set need_end_wblank.
-   *
-   * @return final wblank string
-  */
-  UString combineWblanks();
 
   /**
    * Calculate the initial state of parsing
@@ -392,15 +349,6 @@ private:
    * @param output the stream to write in
    */
   void writeEscapedWithTags(UString const &str, UFILE *output);
-
-
-  /**
-   * Checks if an string ends with a particular suffix
-   * @param str the string to test
-   * @param the searched suffix
-   * @returns true if 'str' has the suffix 'suffix'
-   */
-  static bool endsWith(UString const &str, UString const &suffix);
 
   /**
    * Prints a word
@@ -473,10 +421,6 @@ private:
   void bilingual_wrapper_null_flush(InputFile& input, UFILE *output, GenerationMode mode = gm_unknown);
   void generation_wrapper_null_flush(InputFile& input, UFILE *output,
                                      GenerationMode mode);
-  void postgeneration_wrapper_null_flush(InputFile& input, UFILE *output);
-  void intergeneration_wrapper_null_flush(InputFile& input, UFILE *output);
-  void transliteration_wrapper_null_flush(InputFile& input, UFILE *output);
-
   UString compose(UString const &lexforms, UString const &queue) const;
 
   void procNodeICX();
@@ -498,8 +442,6 @@ public:
   static UString const XML_RESTORE_CHARS_ELEM;
   static UString const XML_VALUE_ATTR;
   static UString const XML_CHAR_ELEM;
-  static UString const WBLANK_START;
-  static UString const WBLANK_END;
   static UString const WBLANK_FINAL;
 
   FSTProcessor();
@@ -508,7 +450,8 @@ public:
   void initTMAnalysis();
   void initSAO(){initAnalysis();};
   void initGeneration();
-  void initPostgeneration();
+  void initPostgeneration(){initTransliteration();};
+  void initTransliteration();
   void initBiltrans();
   void initDecomposition();
 

--- a/lttoolbox/string_utils.cc
+++ b/lttoolbox/string_utils.cc
@@ -247,3 +247,21 @@ StringUtils::caseequal(const UString& a, const UString& b)
   }
   return (cmp == 0);
 }
+
+bool
+StringUtils::endswith(const UString& str, const UString& suffix)
+{
+  return (suffix.size() <= str.size() &&
+          str.substr(str.size()-suffix.size()) == suffix);
+}
+
+UString
+StringUtils::merge_wblanks(const UString& w1, const UString& w2)
+{
+  if (w1.empty()) return w2;
+  if (w2.empty()) return w1;
+  UString ret = w1.substr(0, w1.size()-2);
+  ret += "; "_u;
+  ret += w2.substr(2);
+  return ret;
+}

--- a/lttoolbox/string_utils.h
+++ b/lttoolbox/string_utils.h
@@ -33,6 +33,10 @@ public:
   static UString copycase(const UString& source, const UString& target);
 
   static bool caseequal(const UString& a, const UString& b);
+
+  static bool endswith(const UString& str, const UString& suffix);
+
+  static UString merge_wblanks(const UString& w1, const UString& w2);
 };
 
 #endif // __LT_STRING_UTILS_H__

--- a/tests/basictest.py
+++ b/tests/basictest.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import signal
+from sys import stderr
+
 class Alarm(Exception):
     pass
 
@@ -29,12 +31,14 @@ class BasicTest:
         try:
             char = self.withTimeout(2, process.stdout.read, 1)
         except Alarm:
-            pass
+            print("Timeout before reading a single character!", file=stderr)
         while char and char != b'\0':
             output.append(char)
             try:
                 char = self.withTimeout(2, process.stdout.read, 1)
             except Alarm:
+                print("Timeout before reading %s chars" % len(output),
+                      file=stderr)
                 break           # send what we got up till now
 
         return b"".join(output).decode('utf-8').replace('\r\n', '\n')

--- a/tests/data/postgen-overlap.dix
+++ b/tests/data/postgen-overlap.dix
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dictionary>
+  <alphabet/>
+
+  <pardefs>
+    <pardef n="quotes_empty">
+      <e><i></i></e>
+      <e><i>"</i></e>
+    </pardef>
+  </pardefs>
+
+  <section id="main" type="standard">
+
+	  <e>
+		  <p>
+			  <l>abc</l>
+			  <r>xbc</r>
+		  </p>
+	  </e>
+
+	  <e>
+		  <p>
+			  <l>bc</l>
+			  <r>yc</r>
+		  </p>
+	  </e>
+
+	  <e>
+		  <p>
+			  <l>c</l>
+			  <r>z</r>
+		  </p>
+	  </e>
+
+  </section>
+
+</dictionary>

--- a/tests/data/postgen-short.dix
+++ b/tests/data/postgen-short.dix
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet/>
+  <sdefs>
+    <sdef n="test"/>
+  </sdefs>
+
+  <pardefs>
+   <pardef n="le">
+      <e>
+        <p>
+          <l>la<b/></l>
+          <r>se<b/>la<b/></r>
+        </p>
+      </e>
+    </pardef>
+
+
+  </pardefs>
+
+  <section id="main" type="standard">
+
+	  <e>
+		  <p>
+			  <l><a/>e<b/>a</l>
+			  <r>a</r>
+		  </p>
+	  </e>
+
+  </section>
+
+</dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -155,53 +155,55 @@ class PostgenerationBasicTest(ProcTest):
 class PostgenerationWordboundBlankTest(ProcTest):
     procdix = "data/postgen.dix"
     procflags = ["-p", "-z"]
-    inputs          = [ "xyz ejemplo [[t:i:123456]]~o[[/]] [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
-                        "xyz ejemplo [[t:b:poim230]]~o[[/]] ho [[t:i:mnbj203]]nombre[[/]].",
-                        "xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
-                        "xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] ~le la [[t:b:iopmnb]]nombre[[/]].",
-                        "xyz ejemplo [[t:i:1235gb]]~o[[/]] [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:i4x56fb]]~le[[/]] la nombre.",
-                        "xyz [[t:i:123456]]~le[[/]] [[t:b:123gfv]]la[[/]] pelota.",
-                        "xyz ~le [[t:b:123gfv]]la[[/]] pelota.",
-                        "xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] ~le [[t:b:io1245b]]la[[/]] [[t:b:iopmnb]]nombre[[/]].",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:h5lVhA]]El[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]perro[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:npAFwg]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]~de[[/]] el [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] ~de [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] ~de el [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:abc123; t:i:123456]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:text:NaNaNa]]pla~ss[[/]]",
-                        "[[t:text:NaNaNa]]pla~sss[[/]]",
-                        "[[t:text:NaNaNa]]pla~ssar[[/]]",
-                        "[[t:text:NaNaNa]]pla~sssar[[/]]"]
+    inputs          = [
+        "[l1] xyz ejemplo [[t:i:123456]]~o[[/]] [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+        "[l2] xyz ejemplo [[t:b:poim230]]~o[[/]] ho [[t:i:mnbj203]]nombre[[/]].",
+        "[l3] xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+        "[l4] xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] ~le la [[t:b:iopmnb]]nombre[[/]].",
+        "[l5] xyz ejemplo [[t:i:1235gb]]~o[[/]] [[t:b:abc123; t:i:123456]]ho[[/]] [[t:b:i4x56fb]]~le[[/]] la nombre.",
+        "[l6] xyz [[t:i:123456]]~le[[/]] [[t:b:123gfv]]la[[/]] pelota.",
+        "[l7] xyz ~le [[t:b:123gfv]]la[[/]] pelota.",
+        "[l8] xyz ejemplo ~o [[t:b:abc123; t:i:123456]]ho[[/]] ~le [[t:b:io1245b]]la[[/]] [[t:b:iopmnb]]nombre[[/]].",
+        "[l9] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l10] [[t:b:h5lVhA]]El[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]perro[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:npAFwg]]amigo[[/]][]",
+        "[l11] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]~de[[/]] el [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l12] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] ~de [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l13] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] ~de el [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l14] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
+        "[l15] [[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:abc123; t:i:123456]]testword[[/]]",
+        "[l16] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l17] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l18] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]~les[[/]] [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l19] [[t:b:Z9eiLA]]abc[[/]] ~les [[t:b:12bsa23]]pes[[/]] [[t:i:4_tPUA]]~de[[/]] [[t:b:Z9eiLA]]el[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l20] [[t:text:NaNaNa]]pla~ss[[/]]",
+        "[l21] [[t:text:NaNaNa]]pla~sss[[/]]",
+        "[l22] [[t:text:NaNaNa]]pla~ssar[[/]]",
+        "[l23] [[t:text:NaNaNa]]pla~sssar[[/]]"]
 
-    expectedOutputs = [ "xyz ejemplo [[t:i:123456; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
-                        "xyz ejemplo [[t:b:poim230]]u ho[[/]] [[t:i:mnbj203]]nombre[[/]].",
-                        "xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
-                        "xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] se la [[t:b:iopmnb]]nombre[[/]].",
-                        "xyz ejemplo [[t:i:1235gb; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:i4x56fb]]se la[[/]] nombre.",
-                        "xyz [[t:i:123456; t:b:123gfv]]se la[[/]] pelota.",
-                        "xyz [[t:b:123gfv]]se la[[/]] pelota.",
-                        "xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:io1245b]]se la[[/]] [[t:b:iopmnb]]nombre[[/]].",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:h5lVhA]]El[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]perro[[/]] [[t:b:Z9eiLA; t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:npAFwg]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] del [[t:i:wSM6RQ]]amigo[[/]][]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] le pe test [[t:b:abc123; t:i:123456]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:i:123456; t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:b:Z9eiLA]]abc[[/]] [[t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
-                        "[[t:text:NaNaNa]]plass[[/]]",
-                        "[[t:text:NaNaNa]]plass[[/]]",
-                        "[[t:text:NaNaNa]]plassar[[/]]",
-                        "[[t:text:NaNaNa]]plassar[[/]]"]
+    expectedOutputs = [
+        "[l1] xyz ejemplo [[t:i:123456; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+        "[l2] xyz ejemplo [[t:b:poim230]]u ho[[/]] [[t:i:mnbj203]]nombre[[/]].",
+        "[l3] xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:iopmnb]]nombre[[/]].",
+        "[l4] xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] se la [[t:b:iopmnb]]nombre[[/]].",
+        "[l5] xyz ejemplo [[t:i:1235gb; t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:i4x56fb]]se la[[/]] nombre.",
+        "[l6] xyz [[t:i:123456; t:b:123gfv]]se la[[/]] pelota.",
+        "[l7] xyz [[t:b:123gfv]]se la[[/]] pelota.",
+        "[l8] xyz ejemplo [[t:b:abc123; t:i:123456]]u ho[[/]] [[t:b:io1245b]]se la[[/]] [[t:b:iopmnb]]nombre[[/]].",
+        "[l9] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l10] [[t:b:h5lVhA]]El[[/]] [[t:b:Z9eiLA; t:i:4_tPUA]]perro[[/]] [[t:b:Z9eiLA; t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:npAFwg]]amigo[[/]][]",
+        "[l11] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:i:4_tPUA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l12] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] [[t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l13] [[t:b:Z9eiLA]]El[[/]] [[t:s:8AjRFw]]perro[[/]] del [[t:i:wSM6RQ]]amigo[[/]][]",
+        "[l14] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:b:abc123; t:i:123456]]testword[[/]]",
+        "[l15] [[t:b:Z9eiLA]]abc[[/]] le pe test [[t:b:abc123; t:i:123456]]testword[[/]]",
+        "[l16] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]le pe test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l17] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l18] [[t:b:Z9eiLA]]abc[[/]] [[t:i:123456; t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l19] [[t:b:Z9eiLA]]abc[[/]] [[t:b:12bsa23]]les pes test[[/]] [[t:i:4_tPUA; t:b:Z9eiLA]]del[[/]] [[t:i:wSM6RQ]]testword[[/]]",
+        "[l20] [[t:text:NaNaNa]]plass[[/]]",
+        "[l21] [[t:text:NaNaNa]]plass[[/]]",
+        "[l22] [[t:text:NaNaNa]]plassar[[/]]",
+        "[l23] [[t:text:NaNaNa]]plassar[[/]]"]
 
 
 class PostgenerationWordboundBlankEscapingTest(ProcTest):
@@ -326,6 +328,31 @@ class DebugGen(ProcTest):
                        "^ab<n><indic>/#ab<n><indic>$"]
     procflags = ['-d', '-b', '-z']
     procdir = "rl"
+
+class WordboundBlankNoNestingPostgenTest(ProcTest):
+    procdix = "data/postgen.dix"
+    procflags = ["-p", "-z"]
+    inputs = [
+        "[[t:text:SyTAKg]]xyz~le[[/]][[t:text:SyTAKg]]pqr[[/]]",
+        "[[t:text:SyTAKg]]xyz~les[[/]][[t:text:SyTAKg]]pqr[[/]]",
+    ]
+    expectedOutputs = [
+        "[[t:text:SyTAKg]]xyzle[[/]][[t:text:SyTAKg]]pqr[[/]]",
+        "[[t:text:SyTAKg]]xyzle pe test[[/]][[t:text:SyTAKg]]pqr[[/]]",
+    ]
+
+class PostgenShort(ProcTest):
+    # test for https://github.com/apertium/lttoolbox/issues/123
+    procdix = "data/postgen-short.dix"
+    inputs = ["~e aga", "~E aga"]
+    expectedOutputs = ["aga", "Aga"]
+    procflags = ['-p', '-z']
+
+class PostgenBacktrack(ProcTest):
+    procdix = "data/postgen-overlap.dix"
+    inputs = ["abc"]
+    expectedOutputs = ["xyz"]
+    procflags = ['-p', '-z']
 
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *


### PR DESCRIPTION
Merge postgeneration, intergeneration, and transliteration

* intergen and transliteration now respect wblanks
* postgen now backtracks properly (closes https://github.com/apertium/lttoolbox/issues/123)
* postgen no long requires input to begin with ~ (closes https://github.com/apertium/lttoolbox/issues/42)
* wblank manipulation can no longer produce nested blanks (closes https://github.com/apertium/lttoolbox/issues/145)
* eliminate some dead code

Since I accidentally closed #148 

This still doesn't quite work for -oci, hence the draft status.

```
$ echo "~a ~detla fin" | lttoolbox/lt-proc -p ../apertium-data/apertium-oci/oci.autopgen.bin 
a detla fin
```

(note to self: add -oci pgen to tests)