### PR TITLE
validate-acx: datatype of value is string, not token

### DIFF
--- a/lttoolbox/acx.rng
+++ b/lttoolbox/acx.rng
@@ -3,14 +3,14 @@
   <oneOrMore>
     <element name="char">
       <attribute name="value">
-        <data type="token">
+        <data type="string">
           <param name="length">1</param>
         </data>
       </attribute>
       <oneOrMore>
         <element name="equiv-char">
           <attribute name="value">
-            <data type="token">
+            <data type="string">
               <param name="length">1</param>
             </data>
           </attribute>

--- a/lttoolbox/xsd/acx.xsd
+++ b/lttoolbox/xsd/acx.xsd
@@ -14,7 +14,7 @@
       </xs:sequence>
       <xs:attribute name="value" use="required">
         <xs:simpleType>
-          <xs:restriction base="xs:token">
+          <xs:restriction base="xs:string">
             <xs:length value="1"/>
           </xs:restriction>
         </xs:simpleType>
@@ -25,7 +25,7 @@
     <xs:complexType>
       <xs:attribute name="value" use="required">
         <xs:simpleType>
-          <xs:restriction base="xs:token">
+          <xs:restriction base="xs:string">
             <xs:length value="1"/>
           </xs:restriction>
         </xs:simpleType>


### PR DESCRIPTION
token type calls trim() before checking length restriction. After this
change, it's possible to e.g. use acx to treat nbsp as space.

https://relaxng.org/spec-20011203.html