### PR TITLE
add fst-expander and paradigm generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@
 /lttoolbox/lt-expand
 /lttoolbox/lt-append
 /lttoolbox/lsx-comp
+/lttoolbox/lt-paradigm
 /python/Makefile
 /python/Makefile.in
 /python/lttoolbox.i

--- a/README
+++ b/README
@@ -29,7 +29,14 @@ Executables built by this package:
   would pass through a compiled bidix, creating a new compiled and
   trimmed analyser.
 
-* `lt-print`: print the arcs of a transducer in [ATT format][3].
+* `lt-print`: prints the arcs of a transducer in [ATT format][3].
+
+* `lt-append`: merges two compiled dictionaries.
+
+* `lt-paradigm`: extracts all paths from a compiled dictionary
+  matching an input pattern.
+
+* `lsx-comp`: an alias of `lt-comp`.
 
 There is also a C++ API that you can link to (see how [apertium][1] or
 [apertium-lex-tools][2] do this).

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.52)
 
 m4_define([PKG_VERSION_MAJOR], [3])
 m4_define([PKG_VERSION_MINOR], [6])
-m4_define([PKG_VERSION_PATCH], [8])
+m4_define([PKG_VERSION_PATCH], [9])
 
 AC_INIT([lttoolbox], [PKG_VERSION_MAJOR.PKG_VERSION_MINOR.PKG_VERSION_PATCH], [apertium-stuff@lists.sourceforge.net], [lttoolbox], [https://wiki.apertium.org/wiki/Lttoolbox])
 

--- a/lttoolbox/Makefile.am
+++ b/lttoolbox/Makefile.am
@@ -14,7 +14,7 @@ cc_sources = alphabet.cc att_compiler.cc compiler.cc compression.cc entry_token.
 library_includedir = $(includedir)/$(PACKAGE_NAME)-$(VERSION_API)/$(PACKAGE_NAME)
 library_include_HEADERS = $(h_sources)
 
-bin_PROGRAMS = lt-comp lt-proc lt-expand lt-tmxcomp lt-tmxproc lt-print lt-trim lt-append lsx-comp
+bin_PROGRAMS = lt-comp lt-proc lt-expand lt-paradigm lt-tmxcomp lt-tmxproc lt-print lt-trim lt-append lsx-comp
 instdir = lttoolbox
 
 lib_LTLIBRARIES= liblttoolbox3.la
@@ -37,6 +37,7 @@ lt_trim_SOURCES = lt_trim.cc
 lt_comp_SOURCES = lt_comp.cc
 lt_proc_SOURCES = lt_proc.cc
 lt_expand_SOURCES = lt_expand.cc
+lt_paradigm_SOURCES = lt_paradigm.cc
 lt_tmxcomp_SOURCES = lt_tmxcomp.cc
 lt_tmxproc_SOURCES = lt_tmxproc.cc
 lsx_comp_SOURCES = lt_comp.cc

--- a/lttoolbox/Makefile.am
+++ b/lttoolbox/Makefile.am
@@ -52,7 +52,7 @@ lsx_comp_SOURCES = lt_comp.cc
 
 
 
-man_MANS = lt-append.1 lt-comp.1 lt-expand.1 lt-proc.1 lt-tmxcomp.1 lt-tmxproc.1 lt-print.1 lt-trim.1 lsx-comp.1
+man_MANS = lt-append.1 lt-comp.1 lt-expand.1 lt-paradigm.1 lt-proc.1 lt-tmxcomp.1 lt-tmxproc.1 lt-print.1 lt-trim.1 lsx-comp.1
 
 INCLUDES = -I$(top_srcdir) $(LIBXML_CFLAGS) $(ICU_CFLAGS)
 CLEANFILES = *~

--- a/lttoolbox/alphabet.cc
+++ b/lttoolbox/alphabet.cc
@@ -317,7 +317,7 @@ Alphabet::tokenize(const UString& str) const
         U16_NEXT(str.c_str(), j, end, c);
       }
       if (c == '>') {
-        ret.push_back(operator()(str.substr(i-1, j-i)));
+        ret.push_back(operator()(str.substr(i-1, j-i+1)));
         i = j;
       }
     } else {

--- a/lttoolbox/lt-paradigm.1
+++ b/lttoolbox/lt-paradigm.1
@@ -1,0 +1,41 @@
+.Dd June 30, 2022
+.Dt LT-PARADIGM 1
+.Os Apertium
+.Sh NAME
+.Nm lt-paradigm
+.Nd generate listings from a compiled transducer
+.Sh SYNOPSIS
+.Nm lt-paradigm
+.Op Fl a | z | h
+.Ar fst_file
+.Op Ar input_file Op Ar output_file
+.Sh DESCRIPTION
+.Nm lt-paradigm
+prints paths matching input patterns from a transducer
+.Bl -tag -width Ds
+.It Ar fst_file
+The compiled transducer
+.It Ar input_file
+A list of patterns to be extracted, separated by newlines or nulls
+.It Ar output_file
+All paths matching the patterns in input_file. Each path is terminated by a newline and groups are separated by the separator used in the input.
+.El
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl a Fl Fl analyser
+Match patterns on the right side of the transducer rather than the left.
+.It Fl z Fl Fl null-flush
+No-op, included for compatibility.
+.It Fl h Fl Fl help
+Prints a short help message.
+.El
+.Sh SEE ALSO
+.Xr lt-expand 1 ,
+.Xr hfst-expand 1 ,
+.Sh COPYRIGHT
+Copyright \(co 2022 Apertium
+This is free software.
+You may redistribute copies of it under the terms of
+.Lk https://www.gnu.org/licenses/gpl.html the GNU General Public License .
+.Sh BUGS
+Many... lurking in the dark and waiting for you!

--- a/lttoolbox/lt_paradigm.cc
+++ b/lttoolbox/lt_paradigm.cc
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2022 Apertium
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+#include <lttoolbox/alphabet.h>
+#include <lttoolbox/file_utils.h>
+#include <lttoolbox/input_file.h>
+#include <lttoolbox/lt_locale.h>
+#include <lttoolbox/state.h>
+#include <lttoolbox/trans_exe.h>
+
+#include <getopt.h>
+#include <iostream>
+#include <libgen.h>
+#include <queue>
+
+void endProgram(char* name)
+{
+  std::cout << basename(name) << ": generate listings from a compiled transducer" << std::endl;
+  std::cout << "Usage: " << basename(name) << " [ -a ] FST [ input [ output ] ]" << std::endl;
+  std::cout << "  -a, --analyser:       FST is an analyser (tags on the right)" << std::endl;
+  std::cout << "  -h, --help:           Print this help and exit" << std::endl;
+  exit(EXIT_FAILURE);
+}
+
+void expand(Transducer& inter, int state, const std::set<int>& past_states,
+            const std::vector<int32_t>& syms, const Alphabet& alpha, UFILE* out)
+{
+  if (inter.isFinal(state)) {
+    UString l, r;
+    for (auto& it : syms) {
+      auto pr = alpha.decode(it);
+      alpha.getSymbol(l, pr.first);
+      alpha.getSymbol(r, pr.second);
+    }
+    if (!l.empty() && !r.empty()) {
+      u_fprintf(out, "%S:%S\n", r.c_str(), l.c_str());
+    }
+  }
+  std::set<int> new_states = past_states;
+  new_states.insert(state);
+  for (auto& it : inter.getTransitions()[state]) {
+    if (past_states.find(it.second.first) != past_states.end()) {
+      continue;
+    }
+    std::vector<int32_t> new_syms = syms;
+    new_syms.push_back(it.first);
+    expand(inter, it.second.first, new_states, new_syms, alpha, out);
+  }
+}
+
+void process(const UString& pattern, std::map<UString, Transducer>& trans,
+             Alphabet& alpha,
+             const std::set<UChar32>& letters, const std::set<int32_t> tags,
+             UFILE* output)
+{
+  int32_t any_char = static_cast<int32_t>('*');
+  int32_t any_tag = alpha("<*>"_u);
+  std::vector<int32_t> pat = alpha.tokenize(pattern);
+  Transducer other;
+  int state = other.getInitial();
+  for (auto& it : pat) {
+    if (it == any_char) {
+      state = other.insertNewSingleTransduction(0, state);
+      for (auto& sym : letters) {
+        other.linkStates(state, state, alpha(sym, sym));
+      }
+    } else if (it == any_tag) {
+      state = other.insertNewSingleTransduction(0, state);
+      for (auto& sym : tags) {
+        other.linkStates(state, state, alpha(sym, sym));
+      }
+    } else {
+      state = other.insertNewSingleTransduction(alpha(it, it), state);
+    }
+  }
+  other.setFinal(state);
+  for (auto& it : trans) {
+    Transducer inter = it.second.intersect(other, alpha, alpha);
+    if (!inter.getFinals().empty()) {
+      std::set<int> states;
+      std::vector<int32_t> syms;
+      expand(inter, inter.getInitial(), states, syms, alpha, output);
+    }
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  LtLocale::tryToSetLocale();
+
+  bool should_invert = true;
+
+#if HAVE_GETOPT_LONG
+  static struct option long_options[] =
+    {
+     {"analyser",     0, 0, 'a'},
+     {"null-flush",   0, 0, 'z'},
+     {"help",         0, 0, 'h'},
+     {0,0,0,0}
+    };
+#endif
+
+  while (true) {
+#if HAVE_GETOPT_LONG
+    int c = getopt_long(argc, argv, "azh", long_options, &optind);
+#else
+    int c = getopt(argc, argv, "azh");
+#endif
+    if (c == -1) break;
+
+    switch (c) {
+    case 'a':
+      should_invert = false;
+      break;
+
+    case 'z': // no-op
+      break;
+
+    case 'h':
+    default:
+      endProgram(argv[0]);
+      break;
+    }
+  }
+
+  if (optind == argc) {
+    std::cerr << "Transducer file is required." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  FILE* fst = openInBinFile(argv[optind++]);
+  std::set<UChar32> letters;
+  Alphabet alpha;
+  std::map<UString, Transducer> trans;
+  readTransducerSet(fst, letters, alpha, trans);
+  fclose(fst);
+
+  alpha.includeSymbol("<*>"_u);
+  std::set<int32_t> tags;
+  for (int32_t i = 1; i <= alpha.size(); i++) {
+    tags.insert(-i);
+  }
+
+  if (should_invert) {
+    for (auto& it : trans) {
+      it.second.invert(alpha);
+    }
+  }
+
+  InputFile input;
+  UFILE* output = u_finit(stdout, NULL, NULL);
+  if (optind < argc) {
+    input.open_or_exit(argv[optind++]);
+  }
+  if (optind < argc) {
+    output = openOutTextFile(argv[optind++]);
+  }
+
+  UString cur;
+  do {
+    UChar32 c = input.get();
+    if (c == '\n' || c == '\0' || c == U_EOF) {
+      process(cur, trans, alpha, letters, tags, output);
+      if (c != U_EOF) {
+        u_fputc(c, output);
+        u_fflush(output);
+      }
+      cur.clear();
+    } else {
+      cur += c;
+    }
+  } while (!input.eof());
+
+  u_fclose(output);
+  return 0;
+}

--- a/lttoolbox/lt_paradigm.cc
+++ b/lttoolbox/lt_paradigm.cc
@@ -63,7 +63,7 @@ void expand(Transducer& inter, int state, const std::set<int>& past_states,
 
 void process(const UString& pattern, std::map<UString, Transducer>& trans,
              Alphabet& alpha,
-             const std::set<UChar32>& letters, const std::set<int32_t> tags,
+             const std::set<UChar32>& letters, const std::set<int32_t>& tags,
              UFILE* output)
 {
   int32_t any_char = static_cast<int32_t>('*');

--- a/lttoolbox/transducer.cc
+++ b/lttoolbox/transducer.cc
@@ -1316,3 +1316,19 @@ Transducer::updateAlphabet(Alphabet& old_alpha, Alphabet& new_alpha,
   }
   transitions.swap(new_trans);
 }
+
+void
+Transducer::invert(Alphabet& alpha)
+{
+  std::map<int, std::multimap<int, std::pair<int, double>>> tmp_trans;
+  for (auto& it : transitions) {
+    std::multimap<int, std::pair<int, double>> tmp_state;
+    for (auto& it2 : it.second) {
+      auto pr = alpha.decode(it2.first);
+      int new_sym = alpha(pr.second, pr.first);
+      tmp_state.insert(std::make_pair(new_sym, it2.second));
+    }
+    tmp_trans.insert(std::make_pair(it.first, tmp_state));
+  }
+  transitions.swap(tmp_trans);
+}

--- a/lttoolbox/transducer.h
+++ b/lttoolbox/transducer.h
@@ -424,6 +424,11 @@ public:
    * single symbols rather than pairs.
    */
   void updateAlphabet(Alphabet& old_alpha, Alphabet& new_alpha, bool has_pairs = true);
+
+  /**
+   * Invert all transitions so x:y becomes y:x (this will update alpha).
+   */
+  void invert(Alphabet& alpha);
 };
 
 #endif

--- a/tests/basictest.py
+++ b/tests/basictest.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+import os
+from shutil import rmtree
 import signal
+from subprocess import call, PIPE, Popen
 from sys import stderr
+from tempfile import mkdtemp
 
 class Alarm(Exception):
     pass
@@ -42,3 +46,41 @@ class BasicTest:
                 break           # send what we got up till now
 
         return b"".join(output).decode('utf-8').replace('\r\n', '\n')
+
+    def openPipe(self, procName, args):
+        return Popen([os.environ['LTTOOLBOX_PATH']+'/'+procName] + args,
+                     stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    def closePipe(self, proc, expectFail=False):
+        proc.communicate() # let it terminate
+        proc.stdin.close()
+        proc.stdout.close()
+        proc.stderr.close()
+        retCode = proc.poll()
+        if expectFail:
+            self.assertNotEqual(retCode, 0)
+        else:
+            self.assertEqual(retCode, 0)
+
+    def compileDix(self, dir, dix, flags=None, binName='compiled.bin',
+                   expectFail=False):
+        code = call([os.environ['LTTOOLBOX_PATH']+'/lt-comp']
+                    + (flags or []) + [dir, dix, binName],
+                    stdout=PIPE, stderr=PIPE)
+        if expectFail:
+            self.assertNotEqual(0, code)
+        else:
+            self.assertEqual(0, code)
+        return code == 0
+
+    def callProc(self, name, bins, flags=None, retCode=0):
+        self.assertEqual(retCode,
+                         call([os.environ['LTTOOLBOX_PATH']+'/'+name]
+                              + (flags or []) + bins,
+                              stdout=PIPE, stderr=PIPE))
+
+class TempDir:
+    def __enter__(self):
+        self.tmpd = mkdtemp()
+        return self.tmpd
+    def __exit__(self, *args):
+        rmtree(self.tmpd)

--- a/tests/lt_append/__init__.py
+++ b/tests/lt_append/__init__.py
@@ -1,13 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-import os
 from proctest import ProcTest
-import unittest
-
-from subprocess import Popen, PIPE, call
-from tempfile import mkdtemp
-from shutil import rmtree
 
 class AppendProcTest(ProcTest):
     dix1 = "data/append1.dix"
@@ -17,21 +9,11 @@ class AppendProcTest(ProcTest):
     procflags = ["-z"]
 
     def compileTest(self, tmpd):
-        self.assertEqual(0, call([os.environ['LTTOOLBOX_PATH']+"/lt-comp",
-                                  self.dir1,
-                                  self.dix1,
-                                  tmpd+"/dix1.bin"],
-                                 stdout=PIPE))
-        self.assertEqual(0, call([os.environ['LTTOOLBOX_PATH']+"/lt-comp",
-                                  self.dir2,
-                                  self.dix2,
-                                  tmpd+"/dix2.bin"],
-                                 stdout=PIPE))
-        self.assertEqual(0, call([os.environ['LTTOOLBOX_PATH']+"/lt-append",
-                                  tmpd+"/dix1.bin",
-                                  tmpd+"/dix2.bin",
-                                  tmpd+"/compiled.bin"],
-                                 stdout=PIPE))
+        self.compileDix(self.dir1, self.dix1, binName=tmpd+'/dix1.bin')
+        self.compileDix(self.dir2, self.dix2, binName=tmpd+'/dix2.bin')
+        self.callProc('lt-append', [tmpd+"/dix1.bin",
+                                    tmpd+"/dix2.bin",
+                                    tmpd+"/compiled.bin"])
         return True
 
 class SimpleAppend(AppendProcTest):

--- a/tests/lt_paradigm/__init__.py
+++ b/tests/lt_paradigm/__init__.py
@@ -1,0 +1,23 @@
+from proctest import ProcTest
+
+class ParadigmTest(ProcTest):
+    inputs = ['ab<n><*>', 'y<*>', '*<n><def>']
+    expectedOutputs = ['ab<n><def>:abc\nab<n><ind>:ab',
+                       'y<n><ind>:y',
+                       'ab<n><def>:abc']
+    procdix = 'data/minimal-mono.dix'
+    procdir = 'rl'
+
+    def runTestFlush(self, tmpd):
+        proc = self.openPipe('lt-paradigm',
+                             self.procflags+[tmpd+'/compiled.bin'])
+        self.assertEqual(len(self.inputs), len(self.expectedOutputs))
+        for inp, exp in zip(self.inputs, self.expectedOutputs):
+            out = self.communicateFlush(inp + '\n', proc)
+            srt = '\n'.join(sorted(out.strip().splitlines()))
+            self.assertEqual(srt, exp)
+        self.closePipe(proc, expectFail=self.expectedRetCodeFail)
+
+class ParadigmAnalyzerTest(ParadigmTest):
+    procdir = 'lr'
+    procflags = ['-a']

--- a/tests/lt_print/__init__.py
+++ b/tests/lt_print/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import unittest
 from printtest import PrintTest
 

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from proctest import ProcTest
-
-from typing import List
-
 
 class ValidInput(ProcTest):
     inputs = ["ab",
@@ -226,7 +221,7 @@ class SpaceAtEOF(ProcTest):
     procdix = "data/space-eof-incond.dix"
     inputs          = ['. ']
     expectedOutputs = ['^./.<sent>$ ']
-    procflags = []              # type: List[str]
+    procflags = []
     flushing = False
 
 

--- a/tests/proctest.py
+++ b/tests/proctest.py
@@ -1,14 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import os
-from subprocess import Popen, PIPE, call
-from tempfile import mkdtemp
-from shutil import rmtree
-from basictest import BasicTest
+from basictest import BasicTest, TempDir
 import unittest
-
-from typing import List
-
 
 class ProcTest(unittest.TestCase, BasicTest):
     """See lt_proc test for how to use this. Override runTest if you don't
@@ -24,36 +17,21 @@ class ProcTest(unittest.TestCase, BasicTest):
     flushing = True
 
     def compileTest(self, tmpd):
-        retCode = call([os.environ['LTTOOLBOX_PATH']+"/lt-comp",
-                        self.procdir,
-                        self.procdix,
-						tmpd+"/compiled.bin"],
-					   stdout=PIPE, stderr=PIPE)
-        if self.expectedCompRetCodeFail:
-            self.assertNotEqual(retCode, 0)
-        else:
-            self.assertEqual(retCode, 0)
-        return retCode == 0
+        return self.compileDix(self.procdir, self.procdix,
+                               binName=tmpd+'/compiled.bin',
+                               expectFail=self.expectedCompRetCodeFail)
 
     def runTest(self):
-        tmpd = mkdtemp()
-        try:
+        with TempDir() as tmpd:
             if not self.compileTest(tmpd):
                 return
             if self.flushing:
                 self.runTestFlush(tmpd)
             else:
                 self.runTestNoFlush(tmpd)
-        finally:
-            rmtree(tmpd)
 
     def openProc(self, tmpd):
-        return Popen([os.environ['LTTOOLBOX_PATH']+"/lt-proc"]
-                     + self.procflags
-                     + [tmpd+"/compiled.bin"],
-                     stdin=PIPE,
-                     stdout=PIPE,
-                     stderr=PIPE)
+        return self.openPipe('lt-proc', self.procflags+[tmpd+'/compiled.bin'])
 
     def runTestFlush(self, tmpd):
         proc = self.openProc(tmpd)
@@ -62,15 +40,7 @@ class ProcTest(unittest.TestCase, BasicTest):
         for inp, exp in zip(self.inputs, self.expectedOutputs):
             self.assertEqual(self.communicateFlush(inp+"[][\n]", proc),
                              exp+"[][\n]")
-        proc.communicate()  # let it terminate
-        proc.stdin.close()
-        proc.stdout.close()
-        proc.stderr.close()
-        retCode = proc.poll()
-        if self.expectedRetCodeFail:
-            self.assertNotEqual(retCode, 0)
-        else:
-            self.assertEqual(retCode, 0)
+        self.closePipe(proc, self.expectedRetCodeFail)
 
     def runTestNoFlush(self, tmpd):
         for inp, exp in zip(self.inputs, self.expectedOutputs):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,6 +10,7 @@ import lt_trim
 import lt_print
 import lt_comp
 import lt_append
+import lt_paradigm
 
 os.environ['LTTOOLBOX_PATH'] = '../lttoolbox'
 if len(sys.argv) > 1:
@@ -18,7 +19,7 @@ if len(sys.argv) > 1:
 if __name__ == "__main__":
     os.chdir(os.path.dirname(__file__))
     failures = 0
-    for module in [lt_trim, lt_proc, lt_print, lt_comp, lt_append]:
+    for module in [lt_trim, lt_proc, lt_print, lt_comp, lt_append, lt_paradigm]:
         suite = unittest.TestLoader().loadTestsFromModule(module)
         res = unittest.TextTestRunner(verbosity = 2).run(suite)
         failures += len(res.failures)


### PR DESCRIPTION
This PR adds `lt-paradigm` which is similar to `lt-expand` and `hfst-expand` except that instead of listing all forms in the transducer it only lists those that match an input pattern.

```
$ echo 'sing<vblex><*>' | lttoolbox/lt-paradigm ../apertium-data/apertium-eng/eng.autogen.bin 
sing<vblex><inf>:sing
sing<vblex><pres>:sing
sing<vblex><imp>:sing
sing<vblex><pprs>:singing
sing<vblex><ger>:singing
sing<vblex><subs>:singing
sing<vblex><pres><p3><sg>:sings
sing<vblex><pp>:sung
sing<vblex><past>:sang
```

For each line of the input, `*` is replaced with every letter in the alphabet and `<*>` with every tag and the result is intersected with the fst and the results printed line-by-line.

This is nearly equivalent to `hfst-regexp2fst | hfst-compose -1 - -2 $1 | hfst-expand -c 0` but with different tokenization of the input and there can be multiple lines of input.