### PR TITLE
Compose

### DIFF
--- a/README
+++ b/README
@@ -8,8 +8,8 @@ morphological analysis and generation of words. Analysis is the
 process of splitting a word like `cats` into its lemma `cat` and the
 grammatical information `<n><pl>`. Generation is the opposite process.
 
-The three programs main programs are lt-comp, the compiler, lt-proc,
-the processor, and lt-expand, which generates all possible mappings
+The three main programs are lt-comp, the compiler, lt-proc, the
+processor, and lt-expand, which generates all possible mappings
 between surface forms and lexical forms in the dictionary.
 
 Executables built by this package:
@@ -28,6 +28,10 @@ Executables built by this package:
 * `lt-trim`: trims a compiled analyser to only contain entries which
   would pass through a compiled bidix, creating a new compiled and
   trimmed analyser.
+
+* `lt-compose`: composes two compiled transducers (applying output of
+  the first to input of the second), with support for flipping labels
+  and allowing incomplete matches.
 
 * `lt-print`: prints the arcs of a transducer in [ATT format][3].
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ AC_PREREQ(2.52)
 m4_define([PKG_VERSION_MAJOR], [3])
 m4_define([PKG_VERSION_MINOR], [6])
 m4_define([PKG_VERSION_PATCH], [10])
+m4_include([m4/ax_pthread.m4])
 
 AC_INIT([lttoolbox], [PKG_VERSION_MAJOR.PKG_VERSION_MINOR.PKG_VERSION_PATCH], [apertium-stuff@lists.sourceforge.net], [lttoolbox], [https://wiki.apertium.org/wiki/Lttoolbox])
 
@@ -50,6 +51,9 @@ AC_CHECK_HEADERS([stdlib.h string.h unistd.h stddef.h])
 AC_CHECK_HEADER([utf8cpp/utf8.h], [CPPFLAGS="-I/usr/include/utf8cpp/ $CPPFLAGS"], [
   AC_CHECK_HEADER([utf8.h], [], [AC_MSG_ERROR([You don't have utfcpp installed.])])
 ])
+
+# Checks for POSIX thread support
+AX_PTHREAD([], [AC_MSG_ERROR([Can't find libpthread])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/lttoolbox/Makefile.am
+++ b/lttoolbox/Makefile.am
@@ -14,7 +14,7 @@ cc_sources = acx.cc alphabet.cc att_compiler.cc cli.cc compiler.cc compression.c
 library_includedir = $(includedir)/$(PACKAGE_NAME)-$(VERSION_API)/$(PACKAGE_NAME)
 library_include_HEADERS = $(h_sources)
 
-bin_PROGRAMS = lt-comp lt-proc lt-expand lt-paradigm lt-tmxcomp lt-tmxproc lt-print lt-trim lt-append lsx-comp lt-invert lt-restrict lt-apply-acx
+bin_PROGRAMS = lt-comp lt-proc lt-expand lt-paradigm lt-tmxcomp lt-tmxproc lt-print lt-trim lt-compose lt-append lsx-comp lt-invert lt-restrict lt-apply-acx
 instdir = lttoolbox
 
 lib_LTLIBRARIES= liblttoolbox3.la
@@ -28,12 +28,13 @@ lttoolboxlib = $(prefix)/lib
 
 lttoolbox_DATA = dix.dtd dix.rng dix.rnc acx.rng xsd/dix.xsd xsd/acx.xsd
 
-LDADD = liblttoolbox$(VERSION_MAJOR).la
+LDADD = liblttoolbox$(VERSION_MAJOR).la $(PTHREAD_LIBS)
 AM_LDFLAGS = -llttoolbox$(VERSION_MAJOR) $(LIBXML_LIBS) $(ICU_LIBS)
 
 lt_append_SOURCES = lt_append.cc
 lt_print_SOURCES = lt_print.cc
 lt_trim_SOURCES = lt_trim.cc
+lt_compose_SOURCES = lt_compose.cc
 lt_comp_SOURCES = lt_comp.cc
 lt_proc_SOURCES = lt_proc.cc
 lt_expand_SOURCES = lt_expand.cc
@@ -55,9 +56,9 @@ lt_apply_acx_SOURCES = lt_apply_acx.cc
 
 
 
-man_MANS = lt-append.1 lt-comp.1 lt-expand.1 lt-paradigm.1 lt-proc.1 lt-tmxcomp.1 lt-tmxproc.1 lt-print.1 lt-trim.1 lsx-comp.1
+man_MANS = lt-append.1 lt-comp.1 lt-expand.1 lt-paradigm.1 lt-proc.1 lt-tmxcomp.1 lt-tmxproc.1 lt-print.1 lt-trim.1 lt-compose.1 lsx-comp.1
 
-INCLUDES = -I$(top_srcdir) $(LIBXML_CFLAGS) $(ICU_CFLAGS)
+INCLUDES = -I$(top_srcdir) $(LIBXML_CFLAGS) $(ICU_CFLAGS) $(PTHREAD_CFLAGS)
 CLEANFILES = *~
 
 EXTRA_DIST = dix.dtd dix.rng dix.rnc acx.rng xsd/dix.xsd xsd/acx.xsd $(man_MANS)

--- a/lttoolbox/lt-compose.1
+++ b/lttoolbox/lt-compose.1
@@ -1,0 +1,60 @@
+.Dd September 25, 2022
+.Dt LT-COMPOSE 1
+.Os Apertium
+.Sh NAME
+.Nm lt-compose
+.Nd compiled dictionary composition for Apertium
+.Sh SYNOPSIS
+.Nm lt-compose
+.Ar transducer1_binary
+.Ar transducer2_binary
+.Ar composed_binary
+.Sh DESCRIPTION
+.Nm lt-compose
+is the application responsible for composing two compiled
+dictionaries, matching the output-side of transducer1 with the
+input-side of transducer2. By default, matches are anchored to
+initial/final states, so the transducer2 has to match full paths (in
+regex terms, transducer2 is implicitly surrounded by ^ and $). But
+there is also support for letting transducer2 match sub-paths of
+transducer1 (in which matches become optional, making the composition
+a superset of transducer1). Matching sub-paths means that transducer2
+can start matching in the midst of paths of transducer2 (in regex
+terms, transducer2 is implicitly surrounded in .* on both sides).
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl i , Fl Fl inverted
+Apply transducer2 to the input-side (left) of transducer1 instead of
+the output-side. You would do this when altering the forms of an
+analyser.
+.It Fl a , Fl Fl anywhere
+Allow transducer2 to match sub-paths instead of requiring matching
+initial/final states. Matches then become optional.
+.It Fl j , Fl Fl jobs
+Parallelise composition by using one cpu core per section of
+transducer1. You can also set the environment variable LT_JOBS=true if
+you always want parallelisation where available in lttoolbox.
+.Sh FILES
+.Bl -tag -width Ds
+.It Ar transducer1_binary
+a finite state transducer
+.It Ar transducer2_binary
+a finite state transducer
+.It Ar composed_binary
+a finite state transducer
+.El
+.Sh SEE ALSO
+.Xr apertium 1 ,
+.Xr apertium-tagger 1 ,
+.Xr lt-comp 1 ,
+.Xr lt-expand 1 ,
+.Xr lt-print 1 ,
+.Xr lt-trim 1 ,
+.Xr lt-proc 1
+.Sh AUTHOR
+Copyright \(co 2005-2022 Universitat d'Alacant / Universidad de Alicante.
+This is free software.
+You may redistribute copies of it under the terms of
+.Lk https://www.gnu.org/licenses/gpl.html the GNU General Public License .
+.Sh BUGS
+Many... lurking in the dark and waiting for you!

--- a/lttoolbox/lt_compose.cc
+++ b/lttoolbox/lt_compose.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2005 Universitat d'Alacant / Universidad de Alicante
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+#include <lttoolbox/transducer.h>
+#include <lttoolbox/file_utils.h>
+#include <lttoolbox/cli.h>
+#include <lttoolbox/lt_locale.h>
+#include <iostream>
+#include <thread>
+#include <future>
+
+void
+compose(FILE* file_f, FILE* file_g, FILE* file_gf, bool f_inverted, bool g_anywhere, bool jobs)
+{
+  Alphabet alph_f;
+  std::set<UChar32> letters_f;
+  std::map<UString, Transducer> trans_f;
+  readTransducerSet(file_f, letters_f, alph_f, trans_f);
+  Alphabet alph_g;
+  std::set<UChar32> letters_g;
+  std::map<UString, Transducer> trans_g;
+  readTransducerSet(file_g, letters_g, alph_g, trans_g);
+
+  std::map<UString, Transducer> trans_gf;
+
+  Transducer union_g;
+  for (auto& it : trans_g) {
+    if (union_g.isEmpty()) {
+      union_g = it.second;
+    } else {
+      union_g.unionWith(alph_g, it.second);
+    }
+  }
+  union_g.minimize();
+
+  std::vector<std::future<std::pair<UString, Transducer>>> compositions;
+  for (auto& it : trans_f) {
+    if (it.second.numberOfTransitions() == 0) {
+      std::cerr << "Warning: section " << it.first << " is empty! Skipping it..." << std::endl;
+      continue;
+    }
+    if(jobs) {
+      compositions.push_back(std::async(
+          [](Transducer &f, Transducer &g, Alphabet &alph_f, Alphabet &alph_g,
+             bool f_inverted, bool g_anywhere, UString name) {
+            Transducer gf = f.compose(g, alph_f, alph_g, f_inverted, g_anywhere);
+            if (gf.hasNoFinals()) {
+              std::cerr << "Warning: section " << name
+                        << " had no final state after composing! Skipping it..."
+                        << std::endl;
+              ;
+            } else {
+              gf.minimize();
+            }
+            return std::make_pair(name, gf);
+          },
+          std::ref(it.second), std::ref(union_g), std::ref(alph_f),
+          std::ref(alph_g), f_inverted, g_anywhere, it.first));
+    } else {
+      Transducer gf = it.second.compose(union_g, alph_f, alph_g, f_inverted, g_anywhere);
+      if (gf.hasNoFinals()) {
+        std::cerr << "Warning: section " << it.first
+                  << " had no final state after composing! Skipping it..."
+                  << std::endl;
+        continue;
+      }
+      gf.minimize();
+      trans_gf[it.first] = gf;
+    }
+  }
+  for (auto &thr : compositions) {
+    auto it = thr.get();
+    if (!it.second.hasNoFinals()) {
+      trans_gf[it.first] = it.second;
+    }
+  }
+
+  if (trans_gf.empty()) {
+    std::cerr << "Error: Composition gave empty transducer!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  writeTransducerSet(file_gf, letters_f, alph_f, trans_gf);
+}
+
+
+int main(int argc, char *argv[])
+{
+  LtLocale::tryToSetLocale();
+  CLI cli("compose transducer1 with transducer2", PACKAGE_VERSION);
+  cli.add_bool_arg('i', "inverted", "run composition right-to-left on transducer1");
+  cli.add_bool_arg('a', "anywhere", "don't require anchored matches, let transducer2 optionally compose at any sub-path");
+  cli.add_file_arg("transducer1_bin_file", false);
+  cli.add_file_arg("transducer2_bin_file");
+  cli.add_file_arg("trimmed_bin_file");
+  cli.parse_args(argc, argv);
+
+  FILE* transducer1 = openInBinFile(cli.get_files()[0]);
+  FILE* transducer2 = openInBinFile(cli.get_files()[1]);
+  FILE* composition = openOutBinFile(cli.get_files()[2]);
+
+  bool jobs = false;
+  auto LT_JOBS = std::getenv("LT_JOBS");
+  if(cli.get_bools()["jobs"] || (LT_JOBS != NULL && LT_JOBS[0] != 'n')) {
+    jobs = true;
+  }
+  compose(transducer1, transducer2, composition,
+          cli.get_bools()["inverted"],
+          cli.get_bools()["anywhere"],
+          jobs);
+
+  fclose(transducer1);
+  fclose(transducer2);
+  fclose(composition);
+
+  return 0;
+}

--- a/lttoolbox/lt_trim.cc
+++ b/lttoolbox/lt_trim.cc
@@ -61,6 +61,7 @@ trim(FILE* file_mono, FILE* file_bi, FILE* file_out)
       std::cerr << "Warning: section " << it.first << " is empty! Skipping it..." << std::endl;
       continue;
     }
+    // TODO: parallelise this loop (as in lt_compose.cc)
     Transducer trimmed = it.second.intersect(moved_transducer,
                                              alph_mono,
                                              alph_prefix);

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,0 +1,522 @@
+# ===========================================================================
+#        https://www.gnu.org/software/autoconf-archive/ax_pthread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
+#
+# DESCRIPTION
+#
+#   This macro figures out how to build C programs using POSIX threads. It
+#   sets the PTHREAD_LIBS output variable to the threads library and linker
+#   flags, and the PTHREAD_CFLAGS output variable to any special C compiler
+#   flags that are needed. (The user can also force certain compiler
+#   flags/libs to be tested by setting these environment variables.)
+#
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
+#
+#   NOTE: You are assumed to not only compile your program with these flags,
+#   but also to link with them as well. For example, you might link with
+#   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#
+#   If you are only building threaded programs, you may wish to use these
+#   variables in your default LIBS, CFLAGS, and CC:
+#
+#     LIBS="$PTHREAD_LIBS $LIBS"
+#     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
+#     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
+#
+#   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
+#   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
+#   that name (e.g. PTHREAD_CREATE_UNDETACHED on AIX).
+#
+#   Also HAVE_PTHREAD_PRIO_INHERIT is defined if pthread is found and the
+#   PTHREAD_PRIO_INHERIT symbol is defined when compiling with
+#   PTHREAD_CFLAGS.
+#
+#   ACTION-IF-FOUND is a list of shell commands to run if a threads library
+#   is found, and ACTION-IF-NOT-FOUND is a list of commands to run it if it
+#   is not found. If ACTION-IF-FOUND is not specified, the default action
+#   will define HAVE_PTHREAD.
+#
+#   Please let the authors know if this macro fails on any platform, or if
+#   you have any other suggestions or comments. This macro was based on work
+#   by SGJ on autoconf scripts for FFTW (http://www.fftw.org/) (with help
+#   from M. Frigo), as well as ac_pthread and hb_pthread macros posted by
+#   Alejandro Forero Cuervo to the autoconf macro repository. We are also
+#   grateful for the helpful feedback of numerous users.
+#
+#   Updated for Autoconf 2.68 by Daniel Richard G.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   Copyright (c) 2019 Marc Stevens <marc.stevens@cwi.nl>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 31
+
+AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
+AC_DEFUN([AX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_REQUIRE([AC_PROG_CC])
+AC_REQUIRE([AC_PROG_SED])
+AC_LANG_PUSH([C])
+ax_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on Tru64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
+        ax_pthread_save_CC="$CC"
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test "x$ax_pthread_ok" = "xno"; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        CC="$ax_pthread_save_CC"
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try. Items with a "," contain both
+# C compiler flags (before ",") and linker flags (after ","). Other items
+# starting with a "-" are C compiler flags, and remaining items are
+# library names, except for "none" which indicates that we try without
+# any flags at all, and "pthread-config" which is a program returning
+# the flags for the Pth emulation library.
+
+ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads), Tru64
+#           (Note: HP C rejects this with "bad form for `-t' option")
+# -pthreads: Solaris/gcc (Note: HP C also rejects)
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads and
+#      -D_REENTRANT too), HP C (must be checked before -lpthread, which
+#      is present but should not be used directly; and before -mthreads,
+#      because the compiler interprets this as "-mt" + "-hreads")
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case $host_os in
+
+        freebsd*)
+
+        # -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+        # lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+
+        ax_pthread_flags="-kthread lthread $ax_pthread_flags"
+        ;;
+
+        hpux*)
+
+        # From the cc(1) man page: "[-mt] Sets various -D flags to enable
+        # multi-threading and also sets -lpthread."
+
+        ax_pthread_flags="-mt -pthread pthread $ax_pthread_flags"
+        ;;
+
+        openedition*)
+
+        # IBM z/OS requires a feature-test macro to be defined in order to
+        # enable POSIX threads at all, so give the user a hint if this is
+        # not set. (We don't define these ourselves, as they can affect
+        # other portions of the system API in unpredictable ways.)
+
+        AC_EGREP_CPP([AX_PTHREAD_ZOS_MISSING],
+            [
+#            if !defined(_OPEN_THREADS) && !defined(_UNIX03_THREADS)
+             AX_PTHREAD_ZOS_MISSING
+#            endif
+            ],
+            [AC_MSG_WARN([IBM z/OS requires -D_OPEN_THREADS or -D_UNIX03_THREADS to enable pthreads support.])])
+        ;;
+
+        solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed. (N.B.: The stubs are missing
+        # pthread_cleanup_push, or rather a function called by this macro,
+        # so we could check for that, but who knows whether they'll stub
+        # that too in a future libc.)  So we'll check first for the
+        # standard Solaris way of linking pthreads (-mt -lpthread).
+
+        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
+        ;;
+esac
+
+# Are we compiling with Clang?
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [ax_cv_PTHREAD_CLANG],
+    [ax_cv_PTHREAD_CLANG=no
+     # Note that Autoconf sets GCC=yes for Clang as well as GCC
+     if test "x$GCC" = "xyes"; then
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
+     fi
+    ])
+ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
+
+
+# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
+
+# Note that for GCC and Clang -pthread generally implies -lpthread,
+# except when -nostdlib is passed.
+# This is problematic using libtool to build C++ shared libraries with pthread:
+# [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25460
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=661333
+# [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
+# To solve this, first try -pthread together with -lpthread for GCC
+
+AS_IF([test "x$GCC" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
+
+# Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
+
+AS_IF([test "x$ax_pthread_clang" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread"])
+
+
+# The presence of a feature test macro requesting re-entrant function
+# definitions is, on some systems, a strong hint that pthreads support is
+# correctly enabled
+
+case $host_os in
+        darwin* | hpux* | linux* | osf* | solaris*)
+        ax_pthread_check_macro="_REENTRANT"
+        ;;
+
+        aix*)
+        ax_pthread_check_macro="_THREAD_SAFE"
+        ;;
+
+        *)
+        ax_pthread_check_macro="--"
+        ;;
+esac
+AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+      [ax_pthread_check_cond=0],
+      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
+
+
+if test "x$ax_pthread_ok" = "xno"; then
+for ax_pthread_try_flag in $ax_pthread_flags; do
+
+        case $ax_pthread_try_flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                *,*)
+                PTHREAD_CFLAGS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\1/"`
+                PTHREAD_LIBS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\2/"`
+                AC_MSG_CHECKING([whether pthreads work with "$PTHREAD_CFLAGS" and "$PTHREAD_LIBS"])
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $ax_pthread_try_flag])
+                PTHREAD_CFLAGS="$ax_pthread_try_flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
+                AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$ax_pthread_try_flag])
+                PTHREAD_LIBS="-l$ax_pthread_try_flag"
+                ;;
+        esac
+
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+#                       if $ax_pthread_check_cond
+#                        error "$ax_pthread_check_macro must be defined"
+#                       endif
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+            [ax_pthread_ok=yes],
+            [])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        AC_MSG_RESULT([$ax_pthread_ok])
+        AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+
+
+# Various other checks:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_CACHE_CHECK([for joinable pthread attribute],
+            [ax_cv_PTHREAD_JOINABLE_ATTR],
+            [ax_cv_PTHREAD_JOINABLE_ATTR=unknown
+             for ax_pthread_attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+                 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                                                 [int attr = $ax_pthread_attr; return attr /* ; */])],
+                                [ax_cv_PTHREAD_JOINABLE_ATTR=$ax_pthread_attr; break],
+                                [])
+             done
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
+               test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
+               test "x$ax_pthread_joinable_attr_defined" != "xyes"],
+              [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
+                                  [$ax_cv_PTHREAD_JOINABLE_ATTR],
+                                  [Define to necessary symbol if this constant
+                                   uses a non-standard name on your system.])
+               ax_pthread_joinable_attr_defined=yes
+              ])
+
+        AC_CACHE_CHECK([whether more special flags are required for pthreads],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS=no
+             case $host_os in
+             solaris*)
+             ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
+             ;;
+             esac
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
+               test "x$ax_pthread_special_flags_added" != "xyes"],
+              [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
+               ax_pthread_special_flags_added=yes])
+
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            [ax_cv_PTHREAD_PRIO_INHERIT],
+            [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
+                                             [[int i = PTHREAD_PRIO_INHERIT;
+                                               return i;]])],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
+               test "x$ax_pthread_prio_inherit_defined" != "xyes"],
+              [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
+               ax_pthread_prio_inherit_defined=yes
+              ])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        # More AIX lossage: compile with *_r variant
+        if test "x$GCC" != "xyes"; then
+            case $host_os in
+                aix*)
+                AS_CASE(["x/$CC"],
+                    [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
+                    [#handle absolute path differently from PATH based program lookup
+                     AS_CASE(["x$CC"],
+                         [x/*],
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
+                ;;
+            esac
+        fi
+fi
+
+test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
+
+AC_SUBST([PTHREAD_LIBS])
+AC_SUBST([PTHREAD_CFLAGS])
+AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
+        :
+else
+        ax_pthread_ok=no
+        $2
+fi
+AC_LANG_POP
+])dnl AX_PTHREAD

--- a/tests/data/a2b.dix
+++ b/tests/data/a2b.dix
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+  <sdefs>
+    <sdef n="n" 	c="Noun"/>
+  </sdefs>
+  <pardefs>
+  </pardefs>
+  <section id="main" type="standard">
+    <e><p><l>a</l><r>b</r></p></e>
+  </section>
+</dictionary>

--- a/tests/data/compose1.dix
+++ b/tests/data/compose1.dix
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅabcdefghijklmnopqrstuvwxyzæøåcqwxzCQWXZéèêóòâôÉÊÈÓÔÒÂáàÁÀäÄöÖšŠčČðđÐýÝñÑüÜíÍıİËë-0123456789̇</alphabet>
+  <sdefs>
+    <sdef n="n"/>
+    <sdef n="compound-only-L" 	c="May only be the left-side of a compound"/>
+    <sdef n="compound-R" 	c="May be the right-side of a compound, or a full word"/>
+  </sdefs>
+  <pardefs>
+    <pardef n="cp-L">
+      <e>       <p><l>¤</l>            <r><s n="compound-only-L"/></r></p></e>
+    </pardef>
+  </pardefs>
+
+  <section id="main" type="standard">
+
+    <!-- Assuming we compose with pp2p, -->
+    <!-- this one will have pp¤ before epsilons: -->
+    <e> <p><l>opp¤</l>            <r>opp<s n="n"/><s n="compound-only-L"/></r></p></e>
+
+    <!-- this one will have pp then epsilon because of the pardef then ¤: -->
+    <e> <p><l>app</l> <r>app<s n="n"/></r></p><par n="cp-L"/></e>
+
+    <e><i>py</i><p><l></l> <r><s n="compound-R"/></r></p></e>
+
+    <!-- the first one should not allow analyses with just one p: -->
+    <e><i>upp</i><p><l></l> <r><s n="n"/></r></p></e>
+    <!-- but this one should: -->
+    <e><i>upp</i><p><l></l> <r><s n="n"/></r></p><par n="cp-L"/></e>
+
+    <e><i>tupp</i><p><l></l> <r><s n="n"/></r></p><par n="cp-L"/></e>
+
+  </section>
+</dictionary>

--- a/tests/data/pp2p.dix
+++ b/tests/data/pp2p.dix
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+  <sdefs>
+    <sdef n="n" 	c="Noun"/>
+  </sdefs>
+  <pardefs>
+  </pardefs>
+  <section id="main" type="standard">
+    <e><p><l>pp¤</l><r>p</r></p></e>
+    <e><p><l>pp¤</l><r>pp</r></p></e>
+  </section>
+</dictionary>

--- a/tests/data/upp2up.dix
+++ b/tests/data/upp2up.dix
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+  <alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+  <sdefs>
+    <sdef n="n" 	c="Noun"/>
+  </sdefs>
+  <pardefs>
+  </pardefs>
+  <section id="main" type="standard">
+    <e><p><l>upp¤</l><r>up</r></p></e>
+    <e><p><l>upp¤</l><r>upp</r></p></e>
+    <e><p><l>py</l><r>py</r></p></e>
+  </section>
+</dictionary>

--- a/tests/lt_compose/__init__.py
+++ b/tests/lt_compose/__init__.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+from basictest import ProcTest
+import unittest
+
+
+class ComposeProcTest(unittest.TestCase, ProcTest):
+    monodix = "data/compose1.dix"
+    monodir = "lr"
+    bidix = "data/pp2p.dix"
+    bidir = "lr"
+    procflags = ["-z"]
+    composeflags = ["--inverted", "--anywhere"]
+
+    def compileTest(self, tmpd):
+        self.compileDix(self.monodir, self.monodix, binName=tmpd+'/f.bin')
+        self.compileDix(self.bidir, self.bidix, binName=tmpd+'/g.bin')
+        self.callProc('lt-compose',
+                      self.composeflags + [tmpd+"/f.bin",
+                                           tmpd+"/g.bin",
+                                           tmpd+"/compiled.bin"])
+        # The above already asserts retcode, so if we got this far we know it
+        # compiled fine:
+        return True
+
+
+class ComposeSimpleCompound(ComposeProcTest):
+    procflags = ["-e", "-z"]
+    inputs = ["oppy", "appy",
+              "py",
+              "opp", "app"]
+    expectedOutputs = ["^oppy/opp<n>+py$", "^appy/app<n>+py$",
+                       "^py/py$",
+                       "^opp/*opp$", "^app/*app$"]
+
+
+class ComposeNotEverywhere(ComposeProcTest):
+    procflags = ["-e", "-z"]
+    inputs = ["upp", "up", "uppy"]
+    expectedOutputs = ["^upp/upp<n>$",
+                       "^up/*up$",
+                       "^uppy/upp<n>+py$"]
+
+
+class ComposeAnchored(ComposeProcTest):
+    composeflags = ["--inverted"]
+    bidix = "data/upp2up.dix"
+    procflags = ["-e", "-z"]
+    inputs = ["upp", "up",
+              "tuppy", "tupp",
+              "uppy", "upppy", "py",
+              "opp", "oppy",
+              "app", "appy"]
+    expectedOutputs = ["^upp/*upp$", "^up/*up$",
+                       "^tuppy/*tuppy$", "^tupp/*tupp$",
+                       "^uppy/upp<n>+py$", "^upppy/upp<n>+py$", "^py/py$",
+                       "^opp/*opp$", "^oppy/*oppy$",
+                       "^app/*app$", "^appy/*appy$"
+                       ]

--- a/tests/lt_trim/__init__.py
+++ b/tests/lt_trim/__init__.py
@@ -9,6 +9,7 @@
 from basictest import ProcTest, TempDir
 import unittest
 
+
 class TrimProcTest(unittest.TestCase, ProcTest):
     monodix = "data/minimal-mono.dix"
     monodir = "lr"
@@ -22,6 +23,10 @@ class TrimProcTest(unittest.TestCase, ProcTest):
         self.callProc('lt-trim', [tmpd+"/mono.bin",
                                   tmpd+"/bi.bin",
                                   tmpd+"/compiled.bin"])
+        # The above already asserts retcode, so if we got this far we know it
+        # compiled fine:
+        return True
+
 
 class TrimNormalAndJoin(TrimProcTest):
     inputs = ["abc", "ab", "y", "n", "jg", "jh", "kg"]

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -3,15 +3,14 @@
 import sys
 import os
 sys.path.append(os.path.realpath("."))
-
 import unittest
 
 os.environ['LTTOOLBOX_PATH'] = '../lttoolbox'
 if len(sys.argv) > 1:
-	os.environ['LTTOOLBOX_PATH'] = sys.argv[1]
+    os.environ['LTTOOLBOX_PATH'] = sys.argv[1]
 
 modules = ['lt_proc', 'lt_trim', 'lt_print', 'lt_comp', 'lt_append',
-           'lt_paradigm', 'lt_expand', 'lt_apply_acx']
+           'lt_paradigm', 'lt_expand', 'lt_apply_acx', 'lt_compose']
 
 if __name__ == "__main__":
     os.chdir(os.path.dirname(__file__))


### PR DESCRIPTION
composing a big monodix with a small (40-arc) `triple.bin` is fast: 
```
$ lt-comp lr triple triple.bin
main@standard 16 40

$ time LT_JOBS=yes lttoolbox/lt-compose --inverted nob.automorf.bin triple.bin foo.bin
+++++main@standard 15051 20342
++++main@standard 81232 129975
+++main@standard 64081 113399
++main@standard 50140 102150
+main@standard 52219 107672
final@inconditional 26 77
main@standard 63565 144354
regex@standard 365 7015

real    0m5,353s
user    0m14,699s
sys     0m0,306s
```
(the back and forth via hfst for the same thing was >40s).

It even seems to work :) In this example, triple.dix has `<l>pp¤</l><r>pp</r>` where the monodix has `¤` before compound-lefts,  undoubling consonants before compounds so we can get avoid requiring three consonants in a row in input:
```
$ echo 'toppoeng' |lt-proc -we nob.automorf.bin
^toppoeng/*toppoeng$

$ echo 'toppoeng' |lt-proc -we foo.bin
^toppoeng/topp<n><m><sg><ind><cmp>+poeng<n><nt><sg><ind>/topp<n><m><sg><ind><cmp>+poeng<n><nt><pl><ind>$
```

