### PR TITLE
hardcoded sanity-max state size for case-insensitive matching

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -903,7 +903,7 @@ FSTProcessor::compoundAnalysis(UString input_word)
   {
     UChar val=input_word[i];
 
-    current_state.step_case(val, caseSensitive);
+    current_state.step_case(val, beCaseSensitive(current_state));
 
     if(current_state.size() > MAX_COMBINATIONS)
     {
@@ -1068,7 +1068,7 @@ FSTProcessor::analysis(InputFile& input, UFILE *output)
     {
       rcx_map_ptr = rcx_map.find(val);
       std::set<int> tmpset = rcx_map_ptr->second;
-      if(!u_isupper(val) || caseSensitive)
+      if(!u_isupper(val) || beCaseSensitive(current_state))
       {
         current_state.step(val, tmpset);
       }
@@ -1087,7 +1087,7 @@ FSTProcessor::analysis(InputFile& input, UFILE *output)
     }
     else
     {
-      current_state.step_case(val, caseSensitive);
+       	    current_state.step_case(val, beCaseSensitive(current_state));
     }
 
     if(current_state.size() != 0)
@@ -1580,7 +1580,7 @@ FSTProcessor::generation(InputFile& input, UFILE *output, GenerationMode mode)
       alphabet.getSymbol(sf,val);
       if(current_state.size() > 0)
       {
-        if(!alphabet.isTag(val) && u_isupper(val) && !caseSensitive)
+        if(!alphabet.isTag(val) && u_isupper(val) && !(beCaseSensitive(current_state)))
         {
           if(mode == gm_carefulcase)
           {
@@ -1621,7 +1621,7 @@ FSTProcessor::transliteration(InputFile& input, UFILE *output)
   size_t cur_word = 0;
   size_t cur_pos = 0;
   size_t match_pos = 0;
-  current_state = initial_state;
+  State current_state = initial_state;
   UString last_match;
   int space_diff = 0;
 
@@ -1712,7 +1712,7 @@ FSTProcessor::transliteration(InputFile& input, UFILE *output)
       }
     }
 
-    current_state.step_case_override(sym, caseSensitive);
+    current_state.step_case_override(sym, beCaseSensitive(current_state));
 
     if (current_state.size() == 0 || is_end) {
       if (last_match.empty()) {
@@ -1866,7 +1866,7 @@ FSTProcessor::biltransfull(UStringView input_word, bool with_delim)
     }
     if(current_state.size() != 0)
     {
-      if(!alphabet.isTag(val) && u_isupper(val) && !caseSensitive)
+      if(!alphabet.isTag(val) && u_isupper(val) && !beCaseSensitive(current_state))
       {
         current_state.step(val, u_tolower(val));
       }
@@ -2019,7 +2019,7 @@ FSTProcessor::biltrans(UStringView input_word, bool with_delim)
     }
     if(current_state.size() != 0)
     {
-      if(!alphabet.isTag(val) && u_isupper(val) && !caseSensitive)
+      if(!alphabet.isTag(val) && u_isupper(val) && !beCaseSensitive(current_state))
       {
         current_state.step(val, u_tolower(val));
       }
@@ -2277,7 +2277,7 @@ FSTProcessor::bilingual(InputFile& input, UFILE *output, GenerationMode mode)
       }
       if(current_state.size() != 0)
       {
-        current_state.step_case(val, caseSensitive);
+        current_state.step_case(val, beCaseSensitive(current_state));
       }
       if(current_state.isFinal(all_finals))
       {
@@ -2376,7 +2376,7 @@ FSTProcessor::biltransWithQueue(UStringView input_word, bool with_delim)
     }
     if(current_state.size() != 0)
     {
-      if(!alphabet.isTag(val) && u_isupper(val) && !caseSensitive)
+      if(!alphabet.isTag(val) && u_isupper(val) && !beCaseSensitive(current_state))
       {
         current_state.step(val, u_tolower(val));
       }
@@ -2541,7 +2541,7 @@ FSTProcessor::biltransWithoutQueue(UStringView input_word, bool with_delim)
     }
     if(current_state.size() != 0)
     {
-      if(!alphabet.isTag(val) && u_isupper(val) && !caseSensitive)
+      if(!alphabet.isTag(val) && u_isupper(val) && !beCaseSensitive(current_state))
       {
         current_state.step(val, u_tolower(val));
       }
@@ -2744,7 +2744,7 @@ FSTProcessor::SAO(InputFile& input, UFILE *output)
       last = input_buffer.getPos();
     }
 
-    current_state.step_case(val, caseSensitive);
+    current_state.step_case(val, beCaseSensitive(current_state));
 
     if(current_state.size() != 0)
     {

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -60,11 +60,6 @@ private:
   std::map<UString, TransExe> transducers;
 
   /**
-   * Current state of lexical analysis
-   */
-  State current_state;
-
-  /**
    * Initial state of every token
    */
   State initial_state;
@@ -443,6 +438,19 @@ private:
   bool isLastBlankTM = false;
 
   xmlTextReaderPtr reader;
+
+  static constexpr size_t max_case_insensitive_state_size = 65536;
+  /*
+   * Including lowercased versions for every character can potentially create very large states
+   * (See https://github.com/apertium/lttoolbox/issues/167 ). As a sanity-check we don't do
+   * case-insensitive matching if the state size exceeds max_case_insensitive_state_size.
+   *
+   * @return running with --case-sensitive or state size exceeds max
+   */
+  bool beCaseSensitive(const State& state) {
+    return caseSensitive || state.size() >= max_case_insensitive_state_size;
+  }
+
 public:
 
   /*

--- a/lttoolbox/state.cc
+++ b/lttoolbox/state.cc
@@ -81,7 +81,7 @@ State::copy(State const &s)
   }
 }
 
-int
+size_t
 State::size() const
 {
   return state.size();

--- a/lttoolbox/state.h
+++ b/lttoolbox/state.h
@@ -165,7 +165,7 @@ public:
    * Number of alive transductions
    * @return the size
    */
-  int size() const;
+  size_t size() const;
 
   /**
    * step = apply + epsilonClosure


### PR DESCRIPTION
As suggested in https://github.com/apertium/lttoolbox/issues/167#issuecomment-1276703418 , stop doing the case-insensitive matching when we've got a high number of State sequences.

Currently 65536, quite high but at least within what most modern machines can deal with.

Also, delete FSTProcessor.current_state since confusingly all the processors (except transliteration) make a local State called current_state



```sh
$ cat a.dix 
<?xml version="1.0" encoding="UTF-8"?>
<dictionary>
<alphabet/>
<sdefs>
  <sdef n="guess"       c="Guesser"/>
</sdefs>

<pardefs>
<pardef n="a-zA-Z+">
  <e><re>[a-zA-Z]+</re></e>
</pardef>
</pardefs>

<section id="regex" type="standard">
<e><par n="a-zA-Z+"/><p><l/><r><s n="guess"/></r></p></e>
</section>
</dictionary>

$ lt-comp lr a.dix a.bin
regex@standard 3 105

$ echo 'BADGERBADGERBADGERBAD' | \time lt-proc -w a.bin |head -c50 # BEFORE patch
^BADGERBADGERBADGERBAD/bAdGeRbAdGeRbAdGeRBAD<guessCommand terminated by signal 13
5.31user 1.08system 0:06.39elapsed 100%CPU (0avgtext+0avgdata 3815888maxresident)k
0inputs+0outputs (0major+1053716minor)pagefaults 0swaps

$ echo 'BADGERBADGERBADGERAD' | \time lttoolbox/lt-proc -w a.bin |head -c50 # AFTER patch
^BADGERBADGERBADGERAD/bAdGeRbAdGeRBADGERAD<guess>/Command terminated by signal 13
0.16user 0.03system 0:00.20elapsed 102%CPU (0avgtext+0avgdata 65248maxresident)k
0inputs+0outputs (0major+17537minor)pagefaults 0swaps

$ lt-comp rl a.dix g.bin
regex@standard 3 105

$ echo '^BADGERBADGERBADGERBAD<guess>$' | \time lt-proc -g g.bin # BEFORE patch
BADGERBADGERBADGERBAD
3.21user 0.74system 0:03.96elapsed 99%CPU (0avgtext+0avgdata 2544316maxresident)k
0inputs+0outputs (0major+704011minor)pagefaults 0swaps

$ echo '^BADGERBADGERBADGERBAD<guess>$' | \time lttoolbox/lt-proc -g g.bin # AFTER patch
BADGERBADGERBADGERBAD
0.02user 0.01system 0:00.02elapsed 118%CPU (0avgtext+0avgdata 8344maxresident)k
0inputs+0outputs (0major+2079minor)pagefaults 0swaps

# b.bin from issue #167 
$ echo '^BADGERBADGERBADGERBAD<guess>$' | \time lt-proc -b b.bin # BEFORE patch
^BADGERBADGERBADGERBAD<guess>/BADGERBADGERBADGERBAD<guess>$
3.96user 0.91system 0:04.87elapsed 99%CPU (0avgtext+0avgdata 2544488maxresident)k
0inputs+0outputs (0major+704013minor)pagefaults 0swaps

$ echo '^BADGERBADGERBADGERBAD<guess>$' | \time lttoolbox/lt-proc -b b.bin # AFTER patch
^BADGERBADGERBADGERBAD<guess>/BADGERBADGERBADGERBAD<guess>$
0.21user 0.02system 0:00.23elapsed 100%CPU (0avgtext+0avgdata 82504maxresident)k
0inputs+0outputs (0major+21817minor)pagefaults 0swaps
```

Tested both nob→dan (uses lt-proc -g) and nob→nno (uses lt-proc -g -b and lt-proc -p), no diffs on 40k lines of corpus, except nob→dan actually manages to get through its corpus now :)