### PR TITLE
Move log messages to stderr

### DIFF
--- a/lttoolbox/cli.cc
+++ b/lttoolbox/cli.cc
@@ -66,12 +66,12 @@ void CLI::set_epilog(std::string e)
 void CLI::print_usage()
 {
   if (!prog_name.empty()) {
-    std::cout << prog_name;
+    std::cerr << prog_name;
     if (!version.empty()) {
-      std::cout << " v" << version;
+      std::cerr << " v" << version;
     }
-    std::cout << ": " << description << std::endl;
-    std::cout << "USAGE: " << prog_name;
+    std::cerr << ": " << description << std::endl;
+    std::cerr << "USAGE: " << prog_name;
     std::string bargs;
     std::string sargs;
     for (auto& it : options) {
@@ -86,34 +86,34 @@ void CLI::print_usage()
       }
     }
     if (!bargs.empty()) {
-      std::cout << " [-" << bargs << "]";
+      std::cerr << " [-" << bargs << "]";
     }
-    std::cout << sargs;
+    std::cerr << sargs;
     int depth = 0;
     for (auto& it : file_args) {
-      std::cout << ' ';
+      std::cerr << ' ';
       if (it.second) {
-        std::cout << '[';
+        std::cerr << '[';
         depth += 1;
       }
-      std::cout << it.first;
+      std::cerr << it.first;
     }
-    while (depth-- > 0) std::cout << "]";
-    std::cout << std::endl;
+    while (depth-- > 0) std::cerr << "]";
+    std::cerr << std::endl;
     for (auto& it : options) {
-      std::cout << "  -" << it.short_opt;
+      std::cerr << "  -" << it.short_opt;
 #if HAVE_GETOPT_LONG
-      std::cout << ", --" << it.long_opt << ':';
+      std::cerr << ", --" << it.long_opt << ':';
       for (size_t i = it.long_opt.size(); i < 20; i++) {
-        std::cout << ' ';
+        std::cerr << ' ';
       }
 #else
-      std::cout << ":    ";
+      std::cerr << ":    ";
 #endif
-      std::cout << it.desc << std::endl;
+      std::cerr << it.desc << std::endl;
     }
     if (!epilog.empty()) {
-      std::cout << epilog << std::endl;
+      std::cerr << epilog << std::endl;
     }
   }
   exit(EXIT_FAILURE);
@@ -151,7 +151,7 @@ void CLI::parse_args(int argc, char* argv[])
       if (it.short_opt == cnt) {
         found = true;
         if (it.short_opt == 'v' && it.long_opt == "version") {
-          std::cout << prog_name << " version " << version << std::endl;
+          std::cerr << prog_name << " version " << version << std::endl;
           exit(EXIT_SUCCESS);
         }
         if (it.is_bool) {

--- a/lttoolbox/lt_comp.cc
+++ b/lttoolbox/lt_comp.cc
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
   if(opc == "lr")
   {
     if (have_vl) {
-      std::cout << "Error: -l specified, but mode is lr" << std::endl;
+      std::cerr << "Error: -l specified, but mode is lr" << std::endl;
       cli.print_usage();
     }
     if(ttype == 'a')
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
   else if(opc == "rl")
   {
     if (have_vr) {
-      std::cout << "Error: -r specified, but mode is rl" << std::endl;
+      std::cerr << "Error: -r specified, but mode is rl" << std::endl;
       cli.print_usage();
     }
     if(ttype == 'a')

--- a/lttoolbox/lt_tmxcomp.cc
+++ b/lttoolbox/lt_tmxcomp.cc
@@ -27,18 +27,18 @@ void endProgram(char *name)
 {
   if(name != NULL)
   {
-    std::cout << basename(name) << " v" << PACKAGE_VERSION <<": build a letter transducer from a TMX translation memory" << std::endl;
-    std::cout << "USAGE: " << basename(name) << " [OPTIONS] lang1-lang2 tmx_file output_file" << std::endl;
-    std::cout << "Modes:" << std::endl;
-    std::cout << "  lang1:     input language" << std::endl;
-    std::cout << "  lang2:     output language" << std::endl;
-    std::cout << "Options:" << std::endl;
+    std::cerr << basename(name) << " v" << PACKAGE_VERSION <<": build a letter transducer from a TMX translation memory" << std::endl;
+    std::cerr << "USAGE: " << basename(name) << " [OPTIONS] lang1-lang2 tmx_file output_file" << std::endl;
+    std::cerr << "Modes:" << std::endl;
+    std::cerr << "  lang1:     input language" << std::endl;
+    std::cerr << "  lang2:     output language" << std::endl;
+    std::cerr << "Options:" << std::endl;
 #if HAVE_GETOPT_LONG
-    std::cout << "  -o, --origin-code code   the language code to be taken as lang1" << std::endl;
-    std::cout << "  -m, --meta-code code     the language code to be taken as lang2" << std::endl;
+    std::cerr << "  -o, --origin-code code   the language code to be taken as lang1" << std::endl;
+    std::cerr << "  -m, --meta-code code     the language code to be taken as lang2" << std::endl;
 #else
-    std::cout << "  -o code   the language code to be taken as lang1" << std::endl;
-    std::cout << "  -m code   the language code to be taken as lang2" << std::endl;
+    std::cerr << "  -o code   the language code to be taken as lang1" << std::endl;
+    std::cerr << "  -m code   the language code to be taken as lang2" << std::endl;
 #endif
   }
   exit(EXIT_FAILURE);

--- a/lttoolbox/tmx_compiler.cc
+++ b/lttoolbox/tmx_compiler.cc
@@ -430,9 +430,9 @@ TMXCompiler::write(FILE *output)
   Compression::multibyte_write(0, output); // keeping file format
   transducer.write(output);
 
-  std::cout << origin_language << "->" << meta_language << " ";
-  std::cout << transducer.size() << " " << transducer.numberOfTransitions();
-  std::cout << std::endl;
+  std::cerr << origin_language << "->" << meta_language << " ";
+  std::cerr << transducer.size() << " " << transducer.numberOfTransitions();
+  std::cerr << std::endl;
 }
 
 void


### PR DESCRIPTION
Hi everyone, Prompsit fellow here!

The standard way of doing this in Unix is to use stderr. Otherwise, if the program is inside a pipe and fails due to wrong arguments for example, the help message gets scrambled with standard output and input. I also changed the `tmx_compiler.cc` because the method already has an output file, so I'm assuming messages have to go to stderr. But I don't know how that component works and what the printed information means.