### PR TITLE
acx: Add missing <cstdint> include

### DIFF
--- a/lttoolbox/acx.h
+++ b/lttoolbox/acx.h
@@ -18,6 +18,7 @@
 #define _ACXPARSEUTIL_
 
 #include <lttoolbox/sorted_vector.hpp>
+#include <cstdint>
 #include <map>
 
 std::map<int32_t, sorted_vector<int32_t>> readACX(const char* file);


### PR DESCRIPTION
Needed for int32_t. Fixes build w/ musl but also likely gcc 13.

Bug: https://bugs.gentoo.org/889400