### PR TITLE
Add InputFile::open_in_memory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.52)
 
 m4_define([PKG_VERSION_MAJOR], [3])
 m4_define([PKG_VERSION_MINOR], [7])
-m4_define([PKG_VERSION_PATCH], [4])
+m4_define([PKG_VERSION_PATCH], [5])
 
 # Bump if the ABI (not API) changed in a backwards-incompatible manner
 m4_define([PKG_VERSION_ABI], [3])

--- a/lttoolbox/input_file.cc
+++ b/lttoolbox/input_file.cc
@@ -44,6 +44,14 @@ InputFile::open(const char* fname)
   return (infile != nullptr);
 }
 
+bool
+InputFile::open_in_memory(char *input_buffer)
+{
+  close();
+  infile = fmemopen(input_buffer, strlen(input_buffer), "rb");
+  return (infile != nullptr);  
+}
+
 void
 InputFile::open_or_exit(const char* fname)
 {

--- a/lttoolbox/input_file.h
+++ b/lttoolbox/input_file.h
@@ -34,6 +34,7 @@ public:
   InputFile();
   ~InputFile();
   bool open(const char* fname = nullptr);
+  bool open_in_memory(char* input_buffer);
   void open_or_exit(const char* fname = nullptr);
   void close();
   void wrap(FILE* newinfile);


### PR DESCRIPTION
To call FstProcessor::generation without creating files or using I/O, I request that InputFile::open_in_memory be added.