### PR TITLE
lt-proc --surface-biltrans-keep # assume surface in input, keep surface in output

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -2021,7 +2021,7 @@ FSTProcessor::bilingual(InputFile& input, UFILE *output, GenerationMode mode)
     val = tr.second;
 
     //fprintf(stderr, "> %ls : %lc : %d\n", tr.first.c_str(), tr.second, tr.second);
-    if(biltransSurfaceForms && !seensurface && !outOfWord)
+    if((biltransSurfaceForms || biltransSurfaceFormsKeep) && !seensurface && !outOfWord)
     {
       while(val != '/' && val != 0x7fffffff)
       {
@@ -2067,7 +2067,12 @@ FSTProcessor::bilingual(InputFile& input, UFILE *output, GenerationMode mode)
       }
       else if(!result.empty())
       {
-        printWordBilingual(sf, compose(result, queue), output);
+        if(biltransSurfaceFormsKeep) {
+          printWordBilingual(surface + "/"_u + sf, compose(result, queue), output);
+        }
+        else {
+          printWordBilingual(sf, compose(result, queue), output);
+        }
       }
       else
       { //xxx
@@ -2075,6 +2080,10 @@ FSTProcessor::bilingual(InputFile& input, UFILE *output, GenerationMode mode)
         if(biltransSurfaceForms)
         {
           printWordBilingual(surface, prefix + surface, output);
+        }
+        else if(biltransSurfaceFormsKeep)
+        {
+          printWordBilingual(surface + "/"_u + surface, prefix + surface, output);
         }
         else
         {
@@ -2571,6 +2580,12 @@ void
 FSTProcessor::setBiltransSurfaceForms(bool value)
 {
   biltransSurfaceForms = value;
+}
+
+void
+FSTProcessor::setBiltransSurfaceFormsKeep(bool value)
+{
+  biltransSurfaceFormsKeep = value;
 }
 
 void

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -2023,7 +2023,7 @@ FSTProcessor::bilingual(InputFile& input, UFILE *output, GenerationMode mode)
     //fprintf(stderr, "> %ls : %lc : %d\n", tr.first.c_str(), tr.second, tr.second);
     if((biltransSurfaceForms || biltransSurfaceFormsKeep) && !seensurface && !outOfWord)
     {
-      while(val != '/' && val != 0x7fffffff)
+      while(val != '/' && val != '$' && val != 0x7fffffff)
       {
         surface = surface + symbol;
         alphabet.getSymbol(surface, val);
@@ -2032,10 +2032,12 @@ FSTProcessor::bilingual(InputFile& input, UFILE *output, GenerationMode mode)
         val = tr.second;
         //fprintf(stderr, " == %ls : %lc : %d => %ls\n", symbol.c_str(), val, val, surface.c_str());
       }
-      seensurface = true;
-      tr = readBilingual(input, output);
-      symbol = tr.first;
-      val = tr.second;
+      if(val == '/') {         // We've seen the surface form
+        seensurface = true;
+        tr = readBilingual(input, output);
+        symbol = tr.first;
+        val = tr.second;
+      }
     }
 
     if (val == 0x7fffffff)

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -152,9 +152,14 @@ private:
   bool outOfWord = false;
 
   /**
-   * true if we're automatically removing surface forms.
+   * true if we're assuming input has surface forms.
    */
   bool biltransSurfaceForms = false;
+
+  /**
+   * true if we're assuming both input and output should have surface forms.
+   */
+  bool biltransSurfaceFormsKeep = false;
 
 
   /**
@@ -514,6 +519,7 @@ public:
   void setCaseSensitiveMode(bool value);
   void setDictionaryCaseMode(bool value);
   void setBiltransSurfaceForms(bool value);
+  void setBiltransSurfaceFormsKeep(bool value);
   void setIgnoredChars(bool value);
   void setRestoreChars(bool value);
   void setNullFlush(bool value);

--- a/lttoolbox/lt_paradigm.cc
+++ b/lttoolbox/lt_paradigm.cc
@@ -67,7 +67,7 @@ sorted_vector<int32_t> split_tag(UStringView sym, Alphabet& alpha, int prefix,
     tag += '<';
     tag += tg;
     tag += '>';
-    ret.insert(alpha(tag));
+    if (alpha.isSymbolDefined(tag)) ret.insert(alpha(tag));
   }
   return ret;
 }

--- a/lttoolbox/lt_proc.cc
+++ b/lttoolbox/lt_proc.cc
@@ -46,7 +46,8 @@ int main(int argc, char *argv[])
   cli.add_bool_arg('l', "tagged-gen", "morphological generation keeping lexical forms");
   cli.add_bool_arg('m', "tagged-nm-gen", "same as -l but without unknown word marks");
   cli.add_bool_arg('n', "non-marked-gen", "morph. generation without unknown word marks");
-  cli.add_bool_arg('o', "surf-bilingual", "lexical transfer with surface forms");
+  cli.add_bool_arg('o', "surf-bilingual", "lexical transfer, input has surface forms");
+  cli.add_bool_arg('O', "surf-bilingual-keep", "lexical transfer, input and output has surface forms");
   cli.add_bool_arg('p', "post-generation", "post-generation");
   cli.add_bool_arg('x', "inter-generation", "inter-generation");
   cli.add_bool_arg('s', "sao", "SAO annotation system input processing");
@@ -79,6 +80,11 @@ int main(int argc, char *argv[])
     if (cmd && cmd != 'b') cli.print_usage();
     if (!cmd) cmd = 'b';
     fstp.setBiltransSurfaceForms(true);
+  }
+  if (args["surf-bilingual-keep"]) {
+    if (cmd && cmd != 'b') cli.print_usage();
+    if (!cmd) cmd = 'b';
+    fstp.setBiltransSurfaceFormsKeep(true);
   }
   if (args["generation"]) {
     if (cmd && cmd != 'b') cli.print_usage();

--- a/tests/basictest.py
+++ b/tests/basictest.py
@@ -78,8 +78,10 @@ class BasicTest:
             print("STDERR:", res.stderr)
         if expectFail:
             self.assertNotEqual(res.returncode, 0)
+            return False
         else:
             self.assertEqual(res.returncode, 0)
+            return True
 
 
 class TempDir:

--- a/tests/lt_comp/__init__.py
+++ b/tests/lt_comp/__init__.py
@@ -83,7 +83,7 @@ class VariantNoTest(unittest.TestCase, ProcTest):
 class VariantHoTest(unittest.TestCase, ProcTest):
     procdix = 'data/variants.dix'
     procdir = 'lr'
-    compflags = ['--var-right="ho"']
+    compflags = ['--var-right=ho']
     inputs = ['y']
     expectedOutputs = ['^y/y<n><ind>$']
 

--- a/tests/lt_paradigm/__init__.py
+++ b/tests/lt_paradigm/__init__.py
@@ -52,7 +52,7 @@ class OrTagTest(ParadigmTest):
     inputs = ['re<vblex><|pres|pret>', 're<vblex><|inf>', 're<vblex><|xqz>']
     expectedOutputs = [
         're<vblex><pres>:rer\nre<vblex><pres>:res\nre<vblex><pret>:ret',
-        're<vblex><inf>:re\nre<vblex><pret>:ret',
+        're<vblex><inf>:re',
         ''
     ]
 
@@ -65,6 +65,6 @@ class OrTagRepeatTest(ParadigmTest):
     ]
     expectedOutputs = [
         're<vblex><pres>:rer\nre<vblex><pres>:res\nre<vblex><pret>:ret',
-        're<vblex><inf>:re\nre<vblex><pret>:ret',
-        're<vblex><inf>:re\nre<vblex><pret>:ret',
+        're<vblex><inf>:re',
+        're<vblex><inf>:re',
     ]

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -432,6 +432,22 @@ class BufferIndex(ProcTest):
                        ]
 
 
+class Bilsurf(ProcTest):
+    """Test --surf-bilingual"""
+    procdix = "data/minimal-bi.dix"
+    procflags = ['-o', '-z']
+    procdir = "lr"
+    inputs = ["^Ab/ab<n><def>$"]
+    expectedOutputs = ["^ab<n><def>/xy<n><def>$"]
+
+class BilsurfKeep(ProcTest):
+    """Test --surf-bilingual-keep"""
+    procdix = "data/minimal-bi.dix"
+    procflags = ['-O', '-z']
+    procdir = "lr"
+    inputs = ["^Ab/ab<n><def>$"]
+    expectedOutputs = ["^Ab/ab<n><def>/xy<n><def>$"]
+
 class Bigen(ProcTest):
     """Test that we can run -b with -g before, and -b should override it."""
     procdix = "data/minimal-mono.dix"

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -445,8 +445,10 @@ class BilsurfKeep(ProcTest):
     procdix = "data/minimal-bi.dix"
     procflags = ['-O', '-z']
     procdir = "lr"
-    inputs = ["^Ab/ab<n><def>$"]
-    expectedOutputs = ["^Ab/ab<n><def>/xy<n><def>$"]
+    inputs = ["^Ab/ab<n><def>$",
+              "^bad<data>$ ^Ab/ab<n><def>$",]
+    expectedOutputs = ["^Ab/ab<n><def>/xy<n><def>$",
+                       "^bad<data>/bad<data>/@bad<data>$ ^Ab/ab<n><def>/xy<n><def>$"]
 
 class Bigen(ProcTest):
     """Test that we can run -b with -g before, and -b should override it."""


### PR DESCRIPTION
--surf-bilingual:

```sh
$ echo '^Unk/unk<foo>$ ^Sted/sted<n><nt>$' | lt-proc -o nob-nno.autobil.bin 
^Unk/@Unk$ ^sted<n><nt>/stad<n><m>$
```

--surf-bilingual-keep:

```sh
$ echo '^Unk/unk<foo>$ ^Sted/sted<n><nt>$' | lt-proc -O nob-nno.autobil.bin
^Unk/Unk/@Unk$ ^Sted/sted<n><nt>/stad<n><m>$
```
