### PR TITLE
tests: callProc asserts, doesn't return – don't depend on return value

### DIFF
--- a/lttoolbox/lt_paradigm.cc
+++ b/lttoolbox/lt_paradigm.cc
@@ -67,7 +67,7 @@ sorted_vector<int32_t> split_tag(UStringView sym, Alphabet& alpha, int prefix,
     tag += '<';
     tag += tg;
     tag += '>';
-    ret.insert(alpha(tag));
+    if (alpha.isSymbolDefined(tag)) ret.insert(alpha(tag));
   }
   return ret;
 }

--- a/tests/basictest.py
+++ b/tests/basictest.py
@@ -78,8 +78,10 @@ class BasicTest:
             print("STDERR:", res.stderr)
         if expectFail:
             self.assertNotEqual(res.returncode, 0)
+            return False
         else:
             self.assertEqual(res.returncode, 0)
+            return True
 
 
 class TempDir:

--- a/tests/lt_comp/__init__.py
+++ b/tests/lt_comp/__init__.py
@@ -83,7 +83,7 @@ class VariantNoTest(unittest.TestCase, ProcTest):
 class VariantHoTest(unittest.TestCase, ProcTest):
     procdix = 'data/variants.dix'
     procdir = 'lr'
-    compflags = ['--var-right="ho"']
+    compflags = ['--var-right=ho']
     inputs = ['y']
     expectedOutputs = ['^y/y<n><ind>$']
 

--- a/tests/lt_paradigm/__init__.py
+++ b/tests/lt_paradigm/__init__.py
@@ -52,7 +52,7 @@ class OrTagTest(ParadigmTest):
     inputs = ['re<vblex><|pres|pret>', 're<vblex><|inf>', 're<vblex><|xqz>']
     expectedOutputs = [
         're<vblex><pres>:rer\nre<vblex><pres>:res\nre<vblex><pret>:ret',
-        're<vblex><inf>:re\nre<vblex><pret>:ret',
+        're<vblex><inf>:re',
         ''
     ]
 
@@ -65,6 +65,6 @@ class OrTagRepeatTest(ParadigmTest):
     ]
     expectedOutputs = [
         're<vblex><pres>:rer\nre<vblex><pres>:res\nre<vblex><pret>:ret',
-        're<vblex><inf>:re\nre<vblex><pret>:ret',
-        're<vblex><inf>:re\nre<vblex><pret>:ret',
+        're<vblex><inf>:re',
+        're<vblex><inf>:re',
     ]


### PR DESCRIPTION
Several failing tests have been silently passing! I haven't had a chance to look at these yet, but it seems like it would just return instead of asserting after compiling the test data (since compiling always returned `None`  and it just stopped there)