### PR TITLE
let tmx-proc work on space-separated segments as well as those ending in punct

### DIFF
--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -1188,7 +1188,7 @@ FSTProcessor::generation_wrapper_null_flush(InputFile& input, UFILE *output,
 }
 
 void
-FSTProcessor::tm_analysis(InputFile& input, UFILE *output)
+FSTProcessor::tm_analysis(InputFile& input, UFILE *output, TranslationMemoryMode tm_mode)
 {
   State current_state = initial_state;
   UString lf;     //lexical form
@@ -1200,7 +1200,7 @@ FSTProcessor::tm_analysis(InputFile& input, UFILE *output)
     // test for final states
     if(current_state.isFinal(all_finals))
     {
-      if(u_ispunct(val) || u_isspace(val))
+      if(u_ispunct(val) || (tm_mode == tm_space && u_isspace(val)))
       {
         lf = current_state.filterFinalsTM(all_finals, alphabet,
                                           escaped_chars,

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -1200,7 +1200,7 @@ FSTProcessor::tm_analysis(InputFile& input, UFILE *output)
     // test for final states
     if(current_state.isFinal(all_finals))
     {
-      if(u_ispunct(val))
+      if(u_ispunct(val) || u_isspace(val))
       {
         lf = current_state.filterFinalsTM(all_finals, alphabet,
                                           escaped_chars,

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -49,6 +49,16 @@ enum GenerationMode
 };
 
 /**
+ * How the translation memory matches input
+ */
+enum TranslationMemoryMode
+{
+  tm_punct,      // Require punctuation after a match
+  tm_space,      // Require space or punctuation after a match
+};
+
+
+/**
  * Class that implements the FST-based modules of the system
  */
 class FSTProcessor
@@ -493,7 +503,7 @@ public:
   void initDecomposition();
 
   void analysis(InputFile& input, UFILE *output);
-  void tm_analysis(InputFile& input, UFILE *output);
+  void tm_analysis(InputFile& input, UFILE *output, TranslationMemoryMode tm_mode);
   void generation(InputFile& input, UFILE *output, GenerationMode mode = gm_unknown);
   void postgeneration(InputFile& input, UFILE *output);
   void intergeneration(InputFile& input, UFILE *output);

--- a/lttoolbox/lt_tmxproc.cc
+++ b/lttoolbox/lt_tmxproc.cc
@@ -26,7 +26,10 @@ int main(int argc, char *argv[])
   cli.add_file_arg("fst_file", false);
   cli.add_file_arg("input_file");
   cli.add_file_arg("output_file");
+  cli.add_bool_arg('s', "space", "allow a segment to match before space (as well as before punctuation)");
   cli.parse_args(argc, argv);
+
+  TranslationMemoryMode tm_mode = cli.get_bools()["space"] ? tm_space : tm_punct;
 
   FSTProcessor fstp;
   FILE* aux = openInBinFile(cli.get_files()[0]);
@@ -43,7 +46,7 @@ int main(int argc, char *argv[])
   }
   UFILE* output = openOutTextFile(cli.get_files()[2].c_str());
 
-  fstp.tm_analysis(input, output);
+  fstp.tm_analysis(input, output, tm_mode);
 
   u_fclose(output);
   return EXIT_SUCCESS;


### PR DESCRIPTION
The current lt-tmxproc requires that input ends in punctuation for there to be a match (so not full sentence match, just ending in punct, but if your segments are Titlecased it'll probably DWYM 95% of the time). But I'd like it to work on smaller fragments:

```sh
$ lt-tmxcomp foo-bar word.tmx word.tmx.bin
foo->bar 13 12

$ echo 'Addy Domarus – who or what is Addy Domarus?'|lt-tmxproc word.tmx.bin # current master
Addy Domarus – who or what is [Addedomarus]?

$ echo 'Addy Domarus – who or what is Addy Domarus?'| lttoolbox/lt-tmxproc word.tmx.bin # this pull request
[Addedomarus] – who or what is [Addedomarus]?

$ cat word.tmx
```
```xml
<?xml version='1.0' encoding='utf-8'?>
<!DOCTYPE tmx SYSTEM "tmx14.dtd">
<tmx version="1.4">
  <header creationtool="Translate Toolkit - po2tmx" creationtoolversion="1.9.0"
          segtype="sentence" o-tmf="UTF-8" adminlang="foo" srclang="bar" datatype="PlainText"/>
  <body>
    <tu>
      <tuv xml:lang="foo">
        <seg>Addy Domarus</seg>
      </tuv>
      <tuv xml:lang="bar">
        <seg>Addedomarus</seg>
      </tuv>
    </tu>
  </body>
</tmx>
```


Maybe it should be behind a flag though? I don't know how much the TMX functionality is used (@ftyers @xavivars @hectoralos   ?), but I imagine it might break someone's workflow if it is used.