### PR TITLE
New `lt-merge` command to merge LU's from BEG to END tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lttoolbox/liblttoolbox.so.*
 /lttoolbox/lt-comp
 /lttoolbox/lt-compose
 /lttoolbox/lt-proc
+/lttoolbox/lt-merge
 /lttoolbox/lt-trim
 /lttoolbox/Makefile
 /lttoolbox/Makefile.in

--- a/lttoolbox/CMakeLists.txt
+++ b/lttoolbox/CMakeLists.txt
@@ -103,6 +103,9 @@ target_link_libraries(lt-comp lttoolbox ${GETOPT_LIB})
 add_executable(lt-proc lt_proc.cc)
 target_link_libraries(lt-proc lttoolbox ${GETOPT_LIB})
 
+add_executable(lt-merge lt_merge.cc)
+target_link_libraries(lt-merge lttoolbox ${GETOPT_LIB})
+
 add_executable(lt-expand lt_expand.cc)
 target_link_libraries(lt-expand lttoolbox ${GETOPT_LIB})
 
@@ -144,11 +147,11 @@ install(TARGETS lttoolbox
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${LIBLTTOOLBOX_HEADERS}
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lttoolbox)
-install(TARGETS lt-append lt-print lt-trim lt-compose lt-comp lt-proc lt-expand lt-paradigm lt-tmxcomp lt-tmxproc lt-invert lt-restrict lt-apply-acx
+install(TARGETS lt-append lt-print lt-trim lt-compose lt-comp lt-proc lt-merge lt-expand lt-paradigm lt-tmxcomp lt-tmxproc lt-invert lt-restrict lt-apply-acx
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES dix.dtd dix.rng dix.rnc acx.rng xsd/dix.xsd xsd/acx.xsd
 	DESTINATION ${CMAKE_INSTALL_DATADIR}/lttoolbox)
 
-install(FILES lt-append.1 lt-comp.1 lt-expand.1 lt-paradigm.1 lt-proc.1 lt-tmxcomp.1 lt-tmxproc.1 lt-print.1 lt-trim.1 lt-compose.1
+install(FILES lt-append.1 lt-comp.1 lt-expand.1 lt-paradigm.1 lt-proc.1 lt-merge.1 lt-tmxcomp.1 lt-tmxproc.1 lt-print.1 lt-trim.1 lt-compose.1
 	DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)

--- a/lttoolbox/fst_processor.cc
+++ b/lttoolbox/fst_processor.cc
@@ -1967,6 +1967,7 @@ FSTProcessor::quoteMerge(InputFile& input, UFILE *output)
       if(surface.size() > 0) {
         surface += reader.blank;
         appendEscaped(surface, reader.wblank);
+        if(!reader.wblank.empty()) { appendEscaped(surface, "^$"_u); } // otherwise cg-proc will Error wordblank not prior to token
       }
       else {
         // The initial blank should just be output before the merged LU:

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -462,6 +462,15 @@ private:
     }
   }
 
+  void appendEscaped(UString& to, const UString& from) {
+    for(auto &c : from) {
+      if (escaped_chars.find(c) != escaped_chars.end()) {
+        to += u'\\';
+      }
+      to += c;
+    }
+  }
+
 public:
 
   /*
@@ -496,6 +505,7 @@ public:
   UString biltrans(UStringView input_word, bool with_delim = true);
   UString biltransfull(UStringView input_word, bool with_delim = true);
   void bilingual(InputFile& input, UFILE *output, GenerationMode mode = gm_unknown);
+  void quoteMerge(InputFile& input, UFILE *output);
   std::pair<UString, int> biltransWithQueue(UStringView input_word, bool with_delim = true);
   UString biltransWithoutQueue(UStringView input_word, bool with_delim = true);
   void SAO(InputFile& input, UFILE *output);

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -253,6 +253,11 @@ private:
   int maxWeightClasses = INT_MAX;
 
   /**
+   * The alphabet index of the tag <ANY_CHAR>
+   */
+  int any_char;
+
+  /**
    * Prints an error of input stream and exits
    */
   void streamError();

--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -506,6 +506,7 @@ public:
   UString biltransfull(UStringView input_word, bool with_delim = true);
   void bilingual(InputFile& input, UFILE *output, GenerationMode mode = gm_unknown);
   void quoteMerge(InputFile& input, UFILE *output);
+  void quoteUnmerge(InputFile& input, UFILE *output);
   std::pair<UString, int> biltransWithQueue(UStringView input_word, bool with_delim = true);
   UString biltransWithoutQueue(UStringView input_word, bool with_delim = true);
   void SAO(InputFile& input, UFILE *output);

--- a/lttoolbox/lt-merge.1
+++ b/lttoolbox/lt-merge.1
@@ -1,0 +1,40 @@
+.Dd December 10, 2024
+.Dt LT-MERGE 1
+.Os Apertium
+.Sh NAME
+.Nm lt-merge
+.Nd lexical merger for Apertium
+.Sh SYNOPSIS
+.Nm lt-merge
+.Op Fl u
+.Op Ar input_file Op Ar output_file
+.Sh DESCRIPTION
+.Nm lt-merge
+is the application responsible for merging and unmerging
+lexical units
+.Pp
+It accomplishes this.
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl u , Fl Fl unmerge
+Run in reverse, this splits previously merged words.
+.It Fl v , Fl Fl version
+Display the version number.
+.It Fl h , Fl Fl help
+Display this help.
+.El
+\" .Sh FILES
+\" .Bl -tag -width Ds
+\" .It Ar input_file
+\" The input compiled dictionary.
+\" .El
+.Sh SEE ALSO
+.Xr apertium 1 ,
+.Xr lt-proc 1
+.Sh COPYRIGHT
+Copyright \(co 2024 Universitat d'Alacant / Universidad de Alicante.
+This is free software.
+You may redistribute copies of it under the terms of
+.Lk https://www.gnu.org/licenses/gpl.html the GNU General Public License .
+.Sh BUGS
+Many... lurking in the dark and waiting for you!

--- a/lttoolbox/lt_merge.cc
+++ b/lttoolbox/lt_merge.cc
@@ -42,7 +42,12 @@ int main(int argc, char *argv[])
   FSTProcessor fstp;
   fstp.setNullFlush(true); // cf. description of cli["null-flush"]
   fstp.initBiltrans();
-  fstp.quoteMerge(input, output);
+  if(unmerge) {
+    fstp.quoteUnmerge(input, output);
+  }
+  else {
+    fstp.quoteMerge(input, output);
+  }
 
   return 0;
 }

--- a/lttoolbox/lt_merge.cc
+++ b/lttoolbox/lt_merge.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Universitat d'Alacant / Universidad de Alicante
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+#include <lttoolbox/fst_processor.h>
+#include <lttoolbox/file_utils.h>
+#include <lttoolbox/cli.h>
+#include <lttoolbox/lt_locale.h>
+#include <iostream>
+
+
+int main(int argc, char *argv[])
+{
+  LtLocale::tryToSetLocale();
+  CLI cli("merge lexical units from the one tagged BEG until END", PACKAGE_VERSION);
+  cli.add_file_arg("input_file");
+  cli.add_file_arg("output_file");
+  cli.add_bool_arg('u', "unmerge", "Undo the merge");
+  cli.add_bool_arg('z', "null-flush", "flush output on the null character");
+  cli.parse_args(argc, argv);
+
+  auto strs = cli.get_strs();
+  bool unmerge = cli.get_bools()["unmerge"];
+  InputFile input;
+  if (!cli.get_files()[1].empty()) {
+    input.open_or_exit(cli.get_files()[0].c_str());
+  }
+  UFILE* output = openOutTextFile(cli.get_files()[1]);
+
+  FSTProcessor fstp;
+  fstp.setNullFlush(true); // cf. description of cli["null-flush"]
+  fstp.initBiltrans();
+  fstp.quoteMerge(input, output);
+
+  return 0;
+}

--- a/lttoolbox/state.h
+++ b/lttoolbox/state.h
@@ -113,9 +113,9 @@ private:
 
   /**
    * Make a transition, but overriding the output symbol
-   * @param input symbol
-   * @param output symbol we expect to appear
-   * @param output symbol we want to appear
+   * @param input symbol read from infile
+   * @param output symbol from the FST
+   * @param output symbol we want to appear in outfile
    */
   void apply_override(int const input, int const old_sym, int const new_sym);
 

--- a/tests/data/pass-through.lsx
+++ b/tests/data/pass-through.lsx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary type="separable">
+  <alphabet></alphabet>
+  <sdefs>
+    <sdef n="MERGED"/>
+  </sdefs>
+
+  <pardefs>
+    <pardef n="foo">
+      <e>   <i>foo<d/></i>            </e>
+    </pardef>
+  </pardefs>
+
+  <section id="main" type="standard">
+
+    <e c="pass-through MERGED words">
+      <i><w/><s n="MERGED"/></i>
+    </e>
+  </section>
+</dictionary>

--- a/tests/lt_merge/__init__.py
+++ b/tests/lt_merge/__init__.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import unittest
+from basictest import ProcTest
+import unittest
+
+class MergeTest(unittest.TestCase, ProcTest):
+    inputs = ['^nochange<n>$']
+    expectedOutputs = ['^nochange<n>$']
+    procflags = []
+
+    def compileTest(self, tmpd):
+        return True             # "pass"
+
+    def openProc(self, tmpd):
+        return self.openPipe('lt-merge', self.procflags+[])
+
+
+class SimpleTest(MergeTest):
+    inputs = ['^ikke/ikke<adv>$ ^«/«<lquot><MERGE_BEG>$^så/så<adv>$ ^veldig/v<adv>$^»/»<rquot><MERGE_END>$ ^bra/bra<adj>$' ]
+    expectedOutputs = ['^ikke/ikke<adv>$ ^«så veldig»/«så veldig»<MERGED>$ ^bra/bra<adj>$']
+
+
+class SingleTest(MergeTest):
+    inputs = ['^not/very<useful><MERGE_BEG><MERGE_END>$' ]
+    expectedOutputs = ['^not/not<MERGED>$']
+
+
+class UnknownTest(MergeTest):
+    inputs = ['^foo/*foo$' ]
+    expectedOutputs = ['^foo/*foo$']
+
+
+class EscapeTest(MergeTest):
+    # Using r'' to avoid doubling escapes even more:
+    inputs = [r'^ikke/ikke<adv>$ ^«/«<lquot><MERGE_BEG>$^så/så<adv>$ ^ve\[dig/v<adv>$^»/»<rquot><MERGE_END>$ ^bra/bra<adj>$']
+    expectedOutputs = [r'^ikke/ikke<adv>$ ^«så ve\\\[dig»/«så ve\\\[dig»<MERGED>$ ^bra/bra<adj>$']
+
+
+class WordblankTest(MergeTest):
+    # Using r'' to avoid doubling escapes even more:
+    inputs = [r'^«/«<lquot><MERGE_BEG>$[[tf:i:a]]^ve\/ldig/v<adv>$[[/]]^»/»<rquot><MERGE_END>$']
+    expectedOutputs = [r'^«\[\[tf:i:a\]\]ve\\\/ldig\[\[\/\]\]»/«\[\[tf:i:a\]\]ve\\\/ldig\[\[\/\]\]»<MERGED>$']

--- a/tests/lt_merge/__init__.py
+++ b/tests/lt_merge/__init__.py
@@ -38,8 +38,8 @@ class EscapeTest(MergeTest):
 
 class WordblankTest(MergeTest):
     # Using r'' to avoid doubling escapes even more:
-    inputs = [r'^«/«<lquot><MERGE_BEG>$[[tf:i:a]]^ve\/ldig/v<adv>$[[/]]^»/»<rquot><MERGE_END>$']
-    expectedOutputs = [r'^«\[\[tf:i:a\]\]ve\\\/ldig\[\[\/\]\]»/«\[\[tf:i:a\]\]ve\\\/ldig\[\[\/\]\]»<MERGED>$']
+    inputs = [r'^«/«<lquot><MERGE_BEG>$[[tf:i:a]]^ve\/ldig/v<adv>$^»/»<rquot><MERGE_END>$']
+    expectedOutputs = [r'^«\[\[tf:i:a\]\]\^\$ve\\\/ldig»/«\[\[tf:i:a\]\]\^\$ve\\\/ldig»<MERGED>$']
 
 
 class SimpleUnmergeTest(MergeTest):
@@ -52,5 +52,5 @@ class SimpleUnmergeTest(MergeTest):
 class EscapedUnmergeTest(MergeTest):
     procflags = ['--unmerge']
     # Using r'' to avoid doubling escapes even more:
-    inputs = [r'^ikkje<adv>/ikkje$ ^«\[\[tf:i:a\]\]s\\\^å\[\[\/\]\]»<MERGED>/«\[\[tf:i:a\]\]s\\\^å\[\[\/\]\]»$']
-    expectedOutputs = [r'^ikkje<adv>/ikkje$ «[[tf:i:a]]s\^å[[/]]»']
+    inputs = [r'^ikkje<adv>/ikkje$ ^«\[\[tf:i:a\]\]\^\$s\\\^å»<MERGED>/«\[\[tf:i:a\]\]\^\$s\\\^å»$']
+    expectedOutputs = [r'^ikkje<adv>/ikkje$ «[[tf:i:a]]^$s\^å»']

--- a/tests/lt_merge/__init__.py
+++ b/tests/lt_merge/__init__.py
@@ -40,3 +40,17 @@ class WordblankTest(MergeTest):
     # Using r'' to avoid doubling escapes even more:
     inputs = [r'^«/«<lquot><MERGE_BEG>$[[tf:i:a]]^ve\/ldig/v<adv>$[[/]]^»/»<rquot><MERGE_END>$']
     expectedOutputs = [r'^«\[\[tf:i:a\]\]ve\\\/ldig\[\[\/\]\]»/«\[\[tf:i:a\]\]ve\\\/ldig\[\[\/\]\]»<MERGED>$']
+
+
+class SimpleUnmergeTest(MergeTest):
+    procflags = ['--unmerge']
+    # Using r'' to avoid doubling escapes even more:
+    inputs = [r'^ikkje<adv>/ikkje$ ^«Se og Hør»<MERGED>/«Se og Hør»$ ^då<adv>/då$']
+    expectedOutputs = [r'^ikkje<adv>/ikkje$ «Se og Hør» ^då<adv>/då$']
+
+
+class EscapedUnmergeTest(MergeTest):
+    procflags = ['--unmerge']
+    # Using r'' to avoid doubling escapes even more:
+    inputs = [r'^ikkje<adv>/ikkje$ ^«\[\[tf:i:a\]\]s\\\^å\[\[\/\]\]»<MERGED>/«\[\[tf:i:a\]\]s\\\^å\[\[\/\]\]»$']
+    expectedOutputs = [r'^ikkje<adv>/ikkje$ «[[tf:i:a]]s\^å[[/]]»']

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -479,6 +479,11 @@ class BiltransGarbage(ProcTest):
     inputs = ['^$']
     expectedOutputs = ['^$']
 
+class BiltransSimple(ProcTest):
+    procflags = ['-b', '-z']
+    inputs = ['^abc$']
+    expectedOutputs = ['^abc/ab<n><def>$']
+
 class SlashesInTags(ProcTest):
     procdix = 'data/slash-tags.dix'
     procflags = ['-b', '-z']
@@ -495,6 +500,22 @@ class SlashesInTags(ProcTest):
                        '^\\*lobwana1.1<n><3/4><x>/@\\*lobwana1.1<n><3/4><x>$',
                        '^\\*lobwana1.1<n><1/2><a/b>/*lopwana1.1<n><1/2><a/b>$',
                        '^\\*lobwana1.1<n><3/4><a/b>/@\\*lobwana1.1<n><3/4><a/b>$']
+
+class BiltransAnyChar(ProcTest):
+    procdix = 'data/pass-through.lsx'
+    procflags = ['-b', '-z']
+    # Using r'' to avoid doubling escapes even more:
+    inputs = [r'^simple<MERGED>$']
+    expectedOutputs = [r'^simple<MERGED>/simple<MERGED>$']
+
+
+class BiltransAnyCharEscapes(ProcTest):
+    procdix = 'data/pass-through.lsx'
+    procflags = ['-b', '-z']
+    # Using r'' to avoid doubling escapes even more:
+    inputs = [r'^«\[\[tf:i:a\]\]s\\\^å\[\[\/\]\]»<MERGED>$']
+    expectedOutputs = [r'^«\[\[tf:i:a\]\]s\\\^å\[\[\/\]\]»<MERGED>/«\[\[tf:i:a\]\]s\\\^å\[\[\/\]\]»<MERGED>$']
+
 
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -11,7 +11,9 @@ if len(sys.argv) > 1:
 
 modules = ['lt_proc', 'lt_trim', 'lt_print', 'lt_comp', 'lt_append',
            'lt_paradigm', 'lt_expand', 'lt_apply_acx', 'lt_compose',
-           'lt_tmxproc']
+           'lt_tmxproc', 'lt_merge']
+
+# modules = ['lt_merge']
 
 
 if __name__ == "__main__":

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -13,8 +13,6 @@ modules = ['lt_proc', 'lt_trim', 'lt_print', 'lt_comp', 'lt_append',
            'lt_paradigm', 'lt_expand', 'lt_apply_acx', 'lt_compose',
            'lt_tmxproc', 'lt_merge']
 
-# modules = ['lt_merge']
-
 
 if __name__ == "__main__":
     os.chdir(os.path.dirname(__file__))


### PR DESCRIPTION
The reason for this is to be able to use CG (or any tool inside the stream really) to mark which parts of the stream should be shielded from translation, e.g. quotes (but perhaps not all quotes).

The pipeline then becomes something like this:

![image](https://github.com/user-attachments/assets/ba399b80-fc69-4388-bf3f-04c89d09e6cd)


So `lt-merge` runs after tagger:
```sh
$ echo '^ikke/ikke<adv>$ ^«/«<lquot><MERGE_BEG>$^så/så<adv>$ ^veldig/v<adv>$^»/»<rquot><MERGE_END>$ ^bra/bra<adj>$' | lt-merge
```
```r
^ikke/ikke<adv>$ ^«så veldig»/«så veldig»<MERGED>$ ^bra/bra<adj>$
```
If bidix does `<i><w/><s n="MERGED"/></i>` then this passes through unharmed (similarly generator `<i><w/></i><p><l/><r><s n="MERGED"/></r></p>`), and we get

```r
^ikkje<adv>/ikkje$ ^«så veldig»<MERGED>/«så veldig»$ ^bra<adj>/bra$
```
after generation. Then unmerge
```sh
$ echo '^ikkje<adv>/ikkje$ ^«så veldig»<MERGED>/«så veldig»$ ^bra<adj>/bra$' |lt-merge --unmerge
```
```r
^ikkje<adv>/ikkje$ «så veldig» ^bra<adj>/bra$
```
drops it into the stream before cg-proc genprefs.


The tags are hardcoded, `MERGE_BEG`, `MERGE_END` → `MERGED`. I don't see a reason for making them configurable (unless someone else starts using this and has a use-case), they're only used within the `lt-merge` tool so that should have no effect on existing pairs.

We need to be able to pass `MERGED` stuff unchanged through biltrans and generator – this PR adds `ANY_CHAR` (lsx `<w/>`) support to `lt-proc -b`. This is the only change here to existing code, it should have no effect unless you for some reason named your bidix tag `ANY_CHAR` :)

# Effects on people not using this

* `ANY_CHAR` is now treated specially when using `lt-proc -b` (just like it is in lsx)
* there is a new binary called `lt-merge` (should that name be used for something else?)

-----

# Detailed escaping details

Most of the above is simple, but escaping can look a bit messy (this is why we need the `--unmerge`). 

If any of the LU's have word-bound blanks, the `[]` need escaping:

```sh
$ echo '^«/«<lquot><MERGE_BEG>$[[tf:i:a]]^veldig/veldig<adv>$[[/]]^»/»<rquot><MERGE_END>$' | lttoolbox/lt-merge
```
```r
^«\[\[tf:i:a\]\]veldig\[\[\/\]\]»/«\[\[tf:i:a\]\]veldig\[\[\/\]\]»<MERGED>$
```

to ensure we have legal stream format.

If any of the forms contain already escaped chars, these now need double-escaping. Why? We need to know the difference between a `\[` meaning word-blank or `\\[` meaning literal `[`.

We run an "unmerge" step towards the end of the pipeline, while still outputting Apertium Stream Format, which extracts merged forms and drops one level of escaping.

Example of typical quoted char `@`:

```sh
$ echo '^ikke/ikke<adv>$ ^«/«<lquot><MERGE_BEG>$^til/til<pr>$ ^x\@y.com/x\@y.com<email>$^»/»<rquot><MERGE_END>$ ^da/da<adv>$' | lttoolbox/lt-merge
```
```r
^ikke/ikke<adv>$ ^«til x\\\@y.com»/«til x\\\@y.com»<MERGED>$ ^da/da<adv>$
```

If we run `lt-merge` between analysis and wblank-attach, then after the `lt-proc -b generator.bin` step we should have e.g.

```r
^ikkje<adv>/ikkje$ ^«til x\\\@y.com»<MERGED>/«til x\\\@y.com»$ ^då<adv>/då$
```

We extract the merged form:
```sh
$ echo '^ikkje<adv>/ikkje$ ^«til x\\\@y.com»<MERGED>/«til x\\\@y.com»$ ^då<adv>/då$'|lt-merge --unmerge
```
```r
^ikkje<adv>/ikkje$ «til x\@y.com» ^då<adv>/då$
```

Here `\\\@` turned into `\@` – we removed one layer of quoting, but this is still in the apertium stream so special chars stay quoted, e.g. `cg-proc -g` leaves it alone:
```sh
$ echo '^ikkje<adv>/ikkje$ ^«til x\\\@y.com»<MERGED>/«til x\\\@y.com»$ ^då<adv>/då$'|lt-merge --unmerge |cg-proc -1ng nob-nno.genprefs.rlx.bin
```
```r
ikkje «til x\@y.com» då
```

until the final `tf-inject` removes the last escape.

And the word-blanks only have a single `\` so `lt-merge --unmerge` ensures they take effect:

```sh
$ echo '^ikkje<adv>/ikkje$ ^«\[\[tf:i:a\]\]s\\\^å»<MERGED>/«\[\[tf:i:a\]\]s\\\^å»$' | lt-merge --unmerge
```
```r
^ikkje<adv>/ikkje$ «[[tf:i:a]]s\^å»
```

which after `cg-proc -g` becomes

```sh
$ echo '^ikkje<adv>/ikkje$ «[[tf:i:a]]s\^å»' |cg-proc -1ng nob-nno.genprefs.rlx.bin
```
```r
ikkje «[[tf:i:a]]s\^å»
```

which `tf-inject` is happy to handle.

