### PR TITLE
Fallback to analysing lower-cased version on state explosion

### DIFF
--- a/lttoolbox/fst_processor.h
+++ b/lttoolbox/fst_processor.h
@@ -411,6 +411,11 @@ private:
   static UStringView removeTags(UStringView str);
   UString compoundAnalysis(UString str);
 
+  /**
+   * As above, but if compoundAnalysis gives no results, try analysing the lowercased version of str.
+   */
+  UString compoundAnalysisOrLowering(UString str);
+
   struct Indices {
         size_t i_codepoint;
         size_t i_utf16; // always >= i_codepoint since some codepoints take up 2 UTF-16's

--- a/tests/data/big-mono.dix
+++ b/tests/data/big-mono.dix
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dictionary>
+	<alphabet>ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÄÅÆÇÈÉÊËÍÑÒÓÔÕÖØÙÚÜČĐŊŠŦŽabcdefghijklmnopqrstuvwxyzàáâäåæçèéêëíñòóôõöøùúüčđŋšŧž­-</alphabet>
+	<sdefs>
+	  <sdef n="n"/>
+	  <sdef n="np"/>
+	  <sdef n="def"/>
+	  <sdef n="compound-only-L"/>
+	  <sdef n="compound-R"/>
+        </sdefs>
+<pardefs>
+
+</pardefs>
+
+<section id="main" type="standard">
+  <e><p><l>hjerterytmeovervåkningen</l><r>hjerterytmeovervåkning<s n="n"/><s n="def"/></r></p></e>
+  <e><p><l>hjerteklaff</l><r>hjerteklaff<s n="n"/><s n="compound-only-L"/></r></p></e>
+  <e><p><l>overvåkningen</l><r>overvåkning<s n="n"/><s n="def"/><s n="compound-R"/></r></p></e>
+  <e>     <re>[A-ZÆØÅ]+[a-zæøåA-ZÆØÅ]+!</re><p><l/><r><s n="np"/></r></p></e>
+
+  <e><p><l>vas</l><r>vass<s n="n"/><s n="compound-only-L"/></r></p></e>
+  <e><p><l>senga</l><r>seng<s n="n"/><s n="def"/><s n="compound-R"/></r></p></e>
+</section>
+
+
+</dictionary>

--- a/tests/lt_proc/__init__.py
+++ b/tests/lt_proc/__init__.py
@@ -531,6 +531,30 @@ class BiltransGenDebugSymbols(ProcTest):
         '^ab<n><def>#c/#ab<n><def>#c$',
     ]
 
+class BiltransLowerFallback(ProcTest):
+    procdix = 'data/big-mono.dix'
+    procdir = 'rl'
+    procflags = ['-g', '-b', '-z']
+    inputs = [
+        '^HJERTERYTMEOVERVÅKNING<n><def>$',
+    ]
+    expectedOutputs = [
+        '^HJERTERYTMEOVERVÅKNING<n><def>/hjerterytmeovervåkningen$',
+    ]
+
+class AnalysisLowerFallback(ProcTest):
+    procdix = 'data/big-mono.dix'
+    procdir = 'lr'
+    procflags = ['-w', '-e', '-z']
+    inputs = [
+        'Vas vas',
+        'hjerterytmeovervåkningen hjerteklaffovervåkningen HJERTERYTMEOVERVÅKNINGEN HJERTEKLAFFOVERVÅKNINGEN',
+    ]
+    expectedOutputs = [
+        '^Vas/*Vas$ ^vas/*vas$',
+        '^hjerterytmeovervåkningen/hjerterytmeovervåkning<n><def>$ ^hjerteklaffovervåkningen/hjerteklaff<n>+overvåkning<n><def>$ ^HJERTERYTMEOVERVÅKNINGEN/hjerterytmeovervåkning<n><def>$ ^HJERTEKLAFFOVERVÅKNINGEN/hjerteklaff<n>+overvåkning<n><def>$'
+    ]
+
 
 # These fail on some systems:
 #from null_flush_invalid_stream_format import *


### PR DESCRIPTION
both in analysis (lt-proc -a, with or without compounding -e) and in "bilingual generation" (lt-proc -g -b).

fixes #194

This has zero diffs on first 100k words of my bokmål news test corpus (where the longest all-caps word is only 9 letters long, so it never really kicks in).  

When I test on some wiki dumps I get good things like 
```diff
--- /tmp/wiki-before	2025-03-10 14:17:00.793497651 +0100
+++ /tmp/wiki-after	2025-03-10 14:17:43.574880695 +0100
@@ -11 +11 @@
-FOR AT BOKSEN PÅ FRAMSIDA SKAL OPPDATERAST MÅ DU LAGRE DENNE SIDAN OG SÅ TRYKKJE PÅ LENKJA «Oppdater hovudsida» I BOKSEN TIL HØGRE PÅ OVERVÅKNINGSLISTEN DIN.
+FOR AT BOKSEN PÅ FRAMSIDA SKAL OPPDATERAST MÅ DU LAGRE DENNE SIDAN OG SÅ TRYKKJE PÅ LENKJA «Oppdater hovudsida» I BOKSEN TIL HØGRE PÅ OVERVAKINGSLISTA DI.
```