### PR TITLE
Set ICU include flags in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ endif()
 
 # ICU
 find_package(ICU COMPONENTS i18n io uc REQUIRED)
+include_directories(${ICU_INCLUDE_DIRS})
 
 # utf8cpp / utfcpp
 find_path(UTFCPP_INCLUDE_DIRS utf8.h PATH_SUFFIXES utf8cpp utfcpp utf8 REQUIRED)


### PR DESCRIPTION
On OpenBSD, the ICU headers are located in /usr/local, which is not in the default compiler search path. As a result lttoolbox fails to build. Telling cmake to use the ICU include directories it found fixes this.